### PR TITLE
#11 composer.jsonにtest:coverageコマンドを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.idea
 /.vscode
 /.vagrant
+/coverage
 Homestead.json
 Homestead.yaml
 npm-debug.log

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         ],
         "phpcs": "php-cs-fixer fix --dry-run --diff -v --config .php_cs.dist",
         "phpcs:format": "php-cs-fixer fix --diff -v --config .php_cs.dist",
-        "test": "phpunit"
+        "test": "phpunit",
+        "test:coverage": "phpunit --coverage-html coverage"
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/11

# Doneの定義
- `test:coverage` 実行時にプロジェクトルートの `coverage` ディレクトリにHTML形式で出力されている事
- coverageディレクトリがGitの管理対象外になっている事

# 技術的変更点概要
コードカバレッジ出力のための設定を追加。
phpunit.xmlは、プロジェクト作成時のデフォルトの状態としている。
実装が進んだ段階で、テスト対象を`./app/models`配下に限定する予定であるが、
現時点では`./app/models`が存在せずに、コマンド実行時にエラーとなってまうので変更していない。