### PR TITLE
アカウント作成APIのエラー処理を作成する

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,9 @@
 namespace App\Exceptions;
 
 use Exception;
+use App\Models\Domain\ErrorResponseEntityBuilder;
+use App\Models\Domain\exceptions\ValidationException;
+use App\Models\Domain\exceptions\AccountCreatedException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
@@ -46,6 +49,24 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        if ($exception instanceof AccountCreatedException) {
+            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
+            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
+            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
+            $errorResponseEntity = $errorResponseEntityBuilder->build();
+
+            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+        }
+
+        if ($exception instanceof ValidationException) {
+            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
+            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
+            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
+            $errorResponseEntityBuilder->setErrors($exception->getErrors());
+            $errorResponseEntity = $errorResponseEntityBuilder->build();
+
+            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+        }
         return parent::render($request, $exception);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,7 +5,7 @@ namespace App\Exceptions;
 use Exception;
 use App\Models\Domain\ErrorResponseEntityBuilder;
 use App\Models\Domain\exceptions\ValidationException;
-use App\Models\Domain\exceptions\AccountCreatedException;
+use App\Models\Domain\exceptions\BusinessLogicException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
@@ -49,15 +49,6 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-        if ($exception instanceof AccountCreatedException) {
-            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
-            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
-            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
-            $errorResponseEntity = $errorResponseEntityBuilder->build();
-
-            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
-        }
-
         if ($exception instanceof ValidationException) {
             $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
             $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
@@ -67,6 +58,16 @@ class Handler extends ExceptionHandler
 
             return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
         }
+
+        if ($exception instanceof BusinessLogicException) {
+            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
+            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
+            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
+            $errorResponseEntity = $errorResponseEntityBuilder->build();
+
+            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+        }
+
         return parent::render($request, $exception);
     }
 }

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -35,7 +35,7 @@ class AccountController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
-     * @throws \Exception
+     * @throws \App\Models\Domain\exceptions\AccountCreatedException
      */
     public function create(Request $request): JsonResponse
     {

--- a/app/Models/Domain/AccountEntity.php
+++ b/app/Models/Domain/AccountEntity.php
@@ -84,4 +84,14 @@ class AccountEntity
         $accountEntityBuilder->setAccessToken($qiitaAccountValue->getAccessToken());
         return $accountEntityBuilder->build();
     }
+
+    /**
+     * アカウントが作成済みの場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public function accountCreatedMessage(): string
+    {
+        return '既にアカウントの登録が完了しています。';
+    }
 }

--- a/app/Models/Domain/ErrorResponseEntity.php
+++ b/app/Models/Domain/ErrorResponseEntity.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * JsonResponseError
+ */
+
+namespace App\Models\Domain;
+
+/**
+ * Class JsonResponseError
+ * @package App\Models\Domain
+ */
+class ErrorResponseEntity
+{
+    /**
+     * エラーメッセージ
+     *
+     * @var string
+     */
+    private $errorMessage;
+
+    /**
+     * エラーコード
+     *
+     * @var int
+     */
+    private $errorCode;
+
+    /**
+     * エラーの詳細
+     *
+     * @var array
+     */
+    private $errors;
+
+    /**
+     * ErrorResponseEntity constructor.
+     * @param ErrorResponseEntityBuilder $builder
+     */
+    public function __construct(ErrorResponseEntityBuilder $builder)
+    {
+        $this->errorMessage = $builder->getErrorMessage();
+        $this->errorCode = $builder->getErrorCode();
+        $this->errors = $builder->getErrors();
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getErrorCode(): int
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * レスポンスボディを作成する
+     *
+     * @return array
+     */
+    public function buildBody(): array
+    {
+        $data = [
+            'code'    => $this->getErrorCode(),
+            'message' => $this->getErrorMessage(),
+        ];
+
+        if ($this->getErrors() !== []) {
+            $data['errors'] = $this->getErrors();
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/Domain/ErrorResponseEntityBuilder.php
+++ b/app/Models/Domain/ErrorResponseEntityBuilder.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * ErrorResponseEntityBuilder
+ */
+
+namespace App\Models\Domain;
+
+class ErrorResponseEntityBuilder
+{
+    /**
+     * エラーメッセージ
+     *
+     * @var string
+     */
+    private $errorMessage;
+
+    /**
+     * エラーコード
+     *
+     * @var int
+     */
+    private $errorCode;
+
+    /**
+     * エラーの詳細
+     *
+     * @var array
+     */
+    private $errors;
+
+    /**
+     * ErrorResponseEntityBuilder constructor.
+     */
+    public function __construct()
+    {
+        $this->errors = [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @param string $errorMessage
+     */
+    public function setErrorMessage(string $errorMessage): void
+    {
+        $this->errorMessage = $errorMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getErrorCode(): int
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @param int $errorCode
+     */
+    public function setErrorCode(int $errorCode): void
+    {
+        $this->errorCode = $errorCode;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param array $errors
+     */
+    public function setErrors(array $errors): void
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return ErrorResponseEntity
+     */
+    public function build(): ErrorResponseEntity
+    {
+        return new ErrorResponseEntity($this);
+    }
+}

--- a/app/Models/Domain/exceptions/AccountCreatedException.php
+++ b/app/Models/Domain/exceptions/AccountCreatedException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * AccountCreatedException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+use Throwable;
+
+/**
+ * Class AccountCreatedException
+ * @package App\Exceptions
+ */
+class AccountCreatedException extends \Exception
+{
+    const ERROR_MESSAGE = 'Conflict';
+
+    const ERROR_CODE = 409;
+
+    /**
+     * AccountCreatedException constructor.
+     * @param string $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $message = self::ERROR_MESSAGE,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            $message,
+            self::ERROR_CODE,
+            $previous
+        );
+    }
+}

--- a/app/Models/Domain/exceptions/AccountCreatedException.php
+++ b/app/Models/Domain/exceptions/AccountCreatedException.php
@@ -11,7 +11,7 @@ use Throwable;
  * Class AccountCreatedException
  * @package App\Exceptions
  */
-class AccountCreatedException extends \Exception
+class AccountCreatedException extends BusinessLogicException
 {
     const ERROR_MESSAGE = 'Conflict';
 

--- a/app/Models/Domain/exceptions/BusinessLogicException.php
+++ b/app/Models/Domain/exceptions/BusinessLogicException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BusinessLogicException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+/**
+ * Class BusinessLogicException
+ * @package App\Models\Domain\exceptions
+ */
+class BusinessLogicException extends \Exception
+{
+}

--- a/app/Models/Domain/exceptions/ValidationException.php
+++ b/app/Models/Domain/exceptions/ValidationException.php
@@ -11,7 +11,7 @@ use Throwable;
  * Class ValidationException
  * @package App\Models\Domain\exceptions
  */
-class ValidationException extends \Exception
+class ValidationException extends BusinessLogicException
 {
     const ERROR_MESSAGE = 'Unprocessable Entity';
 

--- a/app/Models/Domain/exceptions/ValidationException.php
+++ b/app/Models/Domain/exceptions/ValidationException.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ValidationException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+use Throwable;
+
+/**
+ * Class ValidationException
+ * @package App\Models\Domain\exceptions
+ */
+class ValidationException extends \Exception
+{
+    const ERROR_MESSAGE = 'Unprocessable Entity';
+
+    const ERROR_CODE = 422;
+
+    /**
+     * バリデーションエラーの情報
+     *
+     * @var array
+     */
+    private $errors = [];
+
+    /**
+     * ValidationException constructor.
+     *
+     * @param array $errors
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        array $errors,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            self::ERROR_MESSAGE,
+            self::ERROR_CODE,
+            $previous
+        );
+
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use App\Models\Domain\AccountRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
+use App\Models\Domain\exceptions\AccountCreatedException;
 
 /**
  * Class AccountScenario
@@ -38,7 +39,7 @@ class AccountScenario
      *
      * @param array $requestArray
      * @return array
-     * @throws \Exception
+     * @throws AccountCreatedException
      */
     public function create(array $requestArray): array
     {
@@ -46,6 +47,12 @@ class AccountScenario
         $qiitaAccountValueBuilder->setAccessToken($requestArray['accessToken']);
         $qiitaAccountValueBuilder->setPermanentId($requestArray['permanentId']);
         $qiitaAccountValue = $qiitaAccountValueBuilder->build();
+
+        $accountEntity = $qiitaAccountValue->findAccountEntityByPermanentId($this->accountRepository);
+
+        if ($accountEntity !== '') {
+            throw new AccountCreatedException($accountEntity->accountCreatedMessage());
+        }
 
         $accountEntity = $this->accountRepository->create($qiitaAccountValue);
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/25

# Doneの定義
- アカウントが作成済みの場合エラーが返されること

# 変更点概要

## 仕様的変更点概要
APIのエラーのフォーマットを下記の通り定義。
```
{
    "code":エラーコード,
    "message":"エラーメッセージ",
    "errors":{
        "フィールド名":[
            "エラーエラーメッセージ"
        ],
    }
}
```

`errors`はバリデーション エラーの場合のみ使用される想定。
バリデーション エラーが発生していない場合、送信されない。

例：アカウントが重複して登録された際のエラー
```
{
    "code":409,
    "message":"既にアカウントの登録が完了しています。"
}
```

## 技術的変更点概要
- `Model/Domain`に以下の独自の例外クラスを作成
  - AccountCreatedException.php
  - ValidationException.php

注) `ValidationException.php`について
このIssueでは、バリデーションの実装は行わないが、
APIのエラーレスポンスの実装イメージに必要と判断したため、追加している。

- `ErrorResponseEntity`を作成
独自例外がthrowされた場合、`app/Exceptions/handler.php`内でハンドリングする。
`app/Exceptions/handler.php`にて`ErrorResponseEntity`を生成し、これをもとにJson形式でレスポンスを返す。

# 補足
テストクラスは別のPRにて対応。
curlで確認した場合、レスポンスがUnicodeエスケープされているため下記のサイトで確認した。
https://www.kwonline.org/u_esc_seq.php