### PR TITLE
アカウント登録時の異常系のテストを追加

### DIFF
--- a/app/Models/Domain/AccountEntity.php
+++ b/app/Models/Domain/AccountEntity.php
@@ -90,7 +90,7 @@ class AccountEntity
      *
      * @return string
      */
-    public function accountCreatedMessage(): string
+    public static function accountCreatedMessage(): string
     {
         return '既にアカウントの登録が完了しています。';
     }

--- a/app/Models/Domain/QiitaAccountValue.php
+++ b/app/Models/Domain/QiitaAccountValue.php
@@ -62,8 +62,24 @@ class QiitaAccountValue
         try {
             return $accountRepository->findByPermanentId($this);
         } catch (\Exception $e) {
-            // TODO 独自の例外処理を定義する
+            // TODO RuntimeExceptionをThrowする
             return '';
+        }
+    }
+
+    /**
+     * アカウントが作成済みか確認する
+     *
+     * @param AccountRepository $accountRepository
+     * @return bool
+     */
+    public function isCreatedAccount(AccountRepository $accountRepository): bool
+    {
+        try {
+            $accountRepository->findByPermanentId($this);
+            return true;
+        } catch (\Exception $e) {
+            return false;
         }
     }
 }

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -6,6 +6,7 @@
 namespace App\Services;
 
 use Ramsey\Uuid\Uuid;
+use App\Models\Domain\AccountEntity;
 use App\Models\Domain\AccountRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
@@ -48,10 +49,8 @@ class AccountScenario
         $qiitaAccountValueBuilder->setPermanentId($requestArray['permanentId']);
         $qiitaAccountValue = $qiitaAccountValueBuilder->build();
 
-        $accountEntity = $qiitaAccountValue->findAccountEntityByPermanentId($this->accountRepository);
-
-        if ($accountEntity !== '') {
-            throw new AccountCreatedException($accountEntity->accountCreatedMessage());
+        if ($qiitaAccountValue->isCreatedAccount($this->accountRepository)) {
+            throw new AccountCreatedException(AccountEntity::accountCreatedMessage());
         }
 
         $accountEntity = $this->accountRepository->create($qiitaAccountValue);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/25

# Doneの定義
- アカウントが既に登録されていた場合のテストケースが作成されていること

# 変更点概要

## 技術的変更点概要
- QiitaAccountValueにアカウントが作成済みか確認するメソッド`isCreatedAccount `を追加
- アカウントが作成済みの場合のテストケースを追加