### PR TITLE
ログインAPIのエラー処理を作成する

### DIFF
--- a/app/Infrastructure/Repositories/AccountRepository.php
+++ b/app/Infrastructure/Repositories/AccountRepository.php
@@ -107,6 +107,7 @@ class AccountRepository implements \App\Models\Domain\AccountRepository
         $qiitaAccount = QiitaAccount::where('qiita_account_id', $qiitaAccountValue->getPermanentId())->first();
 
         if ($qiitaAccount === null) {
+            // TODO 独自例外を定義する
             throw new \Exception('qiitaAccountNotFoundException');
         }
 

--- a/app/Models/Domain/AccountEntity.php
+++ b/app/Models/Domain/AccountEntity.php
@@ -94,4 +94,14 @@ class AccountEntity
     {
         return '既にアカウントの登録が完了しています。';
     }
+
+    /**
+     * アカウントが作成されていなかった場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function accountNotFoundMessage(): string
+    {
+        return 'アカウントが登録されていません。アカウント作成ページよりアカウントを作成してください。';
+    }
 }

--- a/app/Models/Domain/QiitaAccountValue.php
+++ b/app/Models/Domain/QiitaAccountValue.php
@@ -55,15 +55,14 @@ class QiitaAccountValue
      * permanentIDからAccountEntityを取得する
      *
      * @param AccountRepository $accountRepository
-     * @return AccountEntity|string
+     * @return AccountEntity
      */
-    public function findAccountEntityByPermanentId(AccountRepository $accountRepository)
+    public function findAccountEntityByPermanentId(AccountRepository $accountRepository): AccountEntity
     {
         try {
             return $accountRepository->findByPermanentId($this);
         } catch (\Exception $e) {
-            // TODO RuntimeExceptionをThrowする
-            return '';
+            throw new \RuntimeException();
         }
     }
 

--- a/app/Models/Domain/exceptions/AccountNotFoundException.php
+++ b/app/Models/Domain/exceptions/AccountNotFoundException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * AccountNotFoundException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+use Throwable;
+
+/**
+ * Class AccountNotFoundException
+ * @package App\Models\Domain\exceptions
+ */
+class AccountNotFoundException extends BusinessLogicException
+{
+    const ERROR_MESSAGE = 'Not Found';
+
+    const ERROR_CODE = 404;
+
+    /**
+     * AccountNotFoundException constructor.
+     * @param string $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $message = self::ERROR_MESSAGE,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            $message,
+            self::ERROR_CODE,
+            $previous
+        );
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/26

# Doneの定義
- アカウントが作成されていない場合エラーが返されること

# 変更点概要

## 仕様的変更点概要
ログイン時にアカウントが作成されていない場合にエラーを返す処理を追加。
エラーレスポンスを以下の通り定義。
```
{  
    "code":404,
    "message":"アカウントが登録されていません。アカウント作成ページよりアカウントを作成してください。"
}
```
## 技術的変更点概要
Model/Domainに以下の独自の例外クラスを作成
- AccountNotFoundException