### PR TITLE
アカウント作成時のバリデーションを追加する

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -36,12 +36,11 @@ class AccountController extends Controller
      * @param Request $request
      * @return JsonResponse
      * @throws \App\Models\Domain\exceptions\AccountCreatedException
+     * @throws \App\Models\Domain\exceptions\ValidationException
      */
     public function create(Request $request): JsonResponse
     {
         $requestArray = $request->json()->all();
-
-        // TODO リクエストのバリデーションを追加する
 
         $sessionId = $this->accountScenario->create($requestArray);
 

--- a/app/Models/Domain/QiitaAccountValue.php
+++ b/app/Models/Domain/QiitaAccountValue.php
@@ -81,4 +81,14 @@ class QiitaAccountValue
             return false;
         }
     }
+
+    /**
+     * アカウント作成時にバリデーションエラーの場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function createAccountValidationErrorMessage(): string
+    {
+        return '不正なリクエストが行われました。再度、アカウント登録を行なってください。';
+    }
 }

--- a/app/Models/Domain/exceptions/ValidationException.php
+++ b/app/Models/Domain/exceptions/ValidationException.php
@@ -27,15 +27,17 @@ class ValidationException extends BusinessLogicException
     /**
      * ValidationException constructor.
      *
+     * @param string $message
      * @param array $errors
      * @param Throwable|null $previous
      */
     public function __construct(
+        string $message = self::ERROR_MESSAGE,
         array $errors,
         Throwable $previous = null
     ) {
         parent::__construct(
-            self::ERROR_MESSAGE,
+            $message,
             self::ERROR_CODE,
             $previous
         );

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -120,12 +120,12 @@ class AccountScenario
     private function validateAccountValue(array $requestArray)
     {
         $validator = \Validator::make($requestArray, [
-            'accessToken' => 'required|alpha_num|min:40|max:64',
+            'accessToken' => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
             'permanentId' => 'required|integer|min:1|max:4294967294',
         ]);
 
         if ($validator->fails()) {
-            throw new ValidationException(QiitaAccountValue::accountCreatedValidationErrorMessage(), $validator->errors()->toArray());
+            throw new ValidationException(QiitaAccountValue::createAccountValidationErrorMessage(), $validator->errors()->toArray());
         }
     }
 }

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -119,8 +119,8 @@ class AccountScenario
     private function validateAccountValue(array $requestArray)
     {
         $validator = \Validator::make($requestArray, [
-            'accessToken' => 'required',
-            'permanentId' => 'required',
+            'accessToken' => 'required|alpha_num|min:40|max:64',
+            'permanentId' => 'required|integer|min:1|max:4294967294',
         ]);
 
         if ($validator->fails()) {

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -8,6 +8,7 @@ namespace App\Services;
 use Ramsey\Uuid\Uuid;
 use App\Models\Domain\AccountEntity;
 use App\Models\Domain\AccountRepository;
+use App\Models\Domain\QiitaAccountValue;
 use App\Models\Domain\LoginSessionRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
@@ -124,7 +125,7 @@ class AccountScenario
         ]);
 
         if ($validator->fails()) {
-            throw new ValidationException($validator->errors()->toArray());
+            throw new ValidationException(QiitaAccountValue::accountCreatedValidationErrorMessage(), $validator->errors()->toArray());
         }
     }
 }

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -244,14 +244,16 @@ class AccountTest extends AbstractTestCase
     public function permanentIdProvider()
     {
         return [
-            'emptyString'       => [''],
-            'null'              => [null],
-            'emptyArray'        => [[]],
-            'string'            => ['a'],
-            'symbol'            => ['1/'],
-            'multiByte'         => ['１'],
-            'negativeNumber'    => [-1],
-            'double'            => [1.1],
+            'emptyString'        => [''],
+            'null'               => [null],
+            'emptyArray'         => [[]],
+            'string'             => ['a'],
+            'symbol'             => ['1/'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [4294967295],
         ];
     }
 }

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -165,4 +165,93 @@ class AccountTest extends AbstractTestCase
             'account_id'   => $accountId,
         ]);
     }
+
+    /**
+     * 異常系のテスト
+     * アカウント作成時のアクセストークンのバリデーション
+     *
+     * @param $accessToken
+     * @dataProvider accessTokenProvider
+     */
+    public function testErrorCreateAccessTokenValidation($accessToken)
+    {
+        $permanentId = '123456';
+
+        $jsonResponse = $this->postJson(
+            '/api/accounts',
+            [
+                'permanentId' => $permanentId,
+                'accessToken' => $accessToken
+            ]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、アカウント登録を行なってください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+
+    /**
+     * アクセストークンのデータプロバイダ
+     *
+     * @return array
+     */
+    public function accessTokenProvider()
+    {
+        return [
+            'emptyString'       => [''],
+            'null'              => [null],
+            'emptyArray'        => [[]],
+            'tooShortLength'    => ['ea5d0a593b2655e9568f144fb1826342292f5c6'], // 39文字
+            'tooLongLength'     => ['ea5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a5a'],  //65文字
+            'symbol'            => ['%a5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a5'],
+            'multiByte'         => ['あa5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a'],
+        ];
+    }
+
+    /**
+     * 異常系のテスト
+     * アカウント作成時のパーマネントIDのバリデーション
+     *
+     * @param $permanentId
+     * @dataProvider permanentIdProvider
+     */
+    public function testErrorCreatePermanentIdValidation($permanentId)
+    {
+        $accessToken = 'ea5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a5';
+
+        $jsonResponse = $this->postJson(
+            '/api/accounts',
+            [
+                'permanentId' => $permanentId,
+                'accessToken' => $accessToken
+            ]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、アカウント登録を行なってください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+
+    /**
+     * パーマネントIDのデータプロバイダ
+     *
+     * @return array
+     */
+    public function permanentIdProvider()
+    {
+        return [
+            'emptyString'       => [''],
+            'null'              => [null],
+            'emptyArray'        => [[]],
+            'string'            => ['a'],
+            'symbol'            => ['1/'],
+            'multiByte'         => ['１'],
+            'negativeNumber'    => [-1],
+            'double'            => [1.1],
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/36

# Doneの定義
- アカウント作成時のバリデーションチェックが追加されていること
- バリデーションエラーの場合、エラーレスポンスが返されること

# 変更点概要

## 仕様的変更点概要
バリデーション処理を追加し、エラーの場合エラーレスポンスを返すように修正。
`errors`のバリデーションのエラーメッセージについては、画面に表示する予定はないため、Laravelのデフォルトのエラーメッセージ(英語のまま)を利用する。
```
{
  "code":422,
  "message":"不正なリクエストが行われました。再度、アカウント登録を行なってください。",
  "errors":{
    "accessToken":["The access token field is required."],
    "permanentId":["The permanent id field is required."]
  }
}
```
## 技術的変更点概要
Validatorファザードを使用して、バリデーションを追加。