### PR TITLE
退会APIのログインセッション不正時のエラー処理を作成

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -52,6 +52,7 @@ class AccountController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\exceptions\UnauthorizedException
      */
     public function destroy(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -52,6 +52,7 @@ class AccountController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      * @throws \App\Models\Domain\exceptions\UnauthorizedException
      */
     public function destroy(Request $request): JsonResponse

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -59,7 +59,6 @@ class AccountController extends Controller
     {
         $sessionId = $request->bearerToken();
 
-        // TODO セッションIDが存在しなかった場合のエラー処理を追加する
         $params = [
             'sessionId' => $sessionId
         ];

--- a/app/Models/Domain/LoginSessionEntity.php
+++ b/app/Models/Domain/LoginSessionEntity.php
@@ -93,4 +93,14 @@ class LoginSessionEntity
     {
         return $accountRepository->find($this->getAccountId());
     }
+
+    /**
+     * ログインセッションの有効期限が切れている場合のエラーメッセージ
+     *
+     * @return string
+     */
+    public function sessionExpiredMessage(): string
+    {
+        return 'セッションの期限が切れました。再度、ログインしてください。';
+    }
 }

--- a/app/Models/Domain/LoginSessionEntity.php
+++ b/app/Models/Domain/LoginSessionEntity.php
@@ -99,8 +99,18 @@ class LoginSessionEntity
      *
      * @return string
      */
-    public function sessionExpiredMessage(): string
+    public function loginSessionExpiredMessage(): string
     {
         return 'セッションの期限が切れました。再度、ログインしてください。';
+    }
+
+    /**
+     * ログインセッションが不正だった場合のエラーメッセージ
+     *
+     * @return string
+     */
+    public static function loginSessionUnauthorizedMessage(): string
+    {
+        return 'セッションが不正です。再度、ログインしてください。';
     }
 }

--- a/app/Models/Domain/LoginSessionEntity.php
+++ b/app/Models/Domain/LoginSessionEntity.php
@@ -68,6 +68,22 @@ class LoginSessionEntity
     }
 
     /**
+     * 有効期限が切れているか確認する
+     *
+     * @return bool
+     */
+    public function isExpired(): bool
+    {
+        $expiredOn = $this->getExpiredOn();
+        $now = new \DateTime();
+
+        if ($expiredOn > $now) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * ログインセッションが持つアカウントのAccountEntityを取得する
      *
      * @param AccountRepository $accountRepository

--- a/app/Models/Domain/exceptions/LoginSessionExpiredException.php
+++ b/app/Models/Domain/exceptions/LoginSessionExpiredException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * LoginSessionExpiredException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+use Throwable;
+
+/**
+ * Class LoginSessionExpiredException
+ * @package App\Models\Domain\exceptions
+ */
+class LoginSessionExpiredException extends BusinessLogicException
+{
+    const ERROR_MESSAGE = 'Unauthorized';
+
+    const ERROR_CODE = 401;
+
+    /**
+     * LoginSessionExpiredException constructor.
+     * @param string $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $message = self::ERROR_MESSAGE,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            $message,
+            self::ERROR_CODE,
+            $previous
+        );
+    }
+}

--- a/app/Models/Domain/exceptions/UnauthorizedException.php
+++ b/app/Models/Domain/exceptions/UnauthorizedException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * UnauthorizedException
+ */
+
+namespace App\Models\Domain\exceptions;
+
+use Throwable;
+
+/**
+ * Class UnauthorizedException
+ * @package App\Models\Domain\exceptions
+ */
+class UnauthorizedException extends BusinessLogicException
+{
+    const ERROR_MESSAGE = 'Unauthorixed';
+
+    const ERROR_CODE = 401;
+
+    /**
+     * UnauthorizedException constructor.
+     * @param string $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $message = self::ERROR_MESSAGE,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            $message,
+            self::ERROR_CODE,
+            $previous
+        );
+    }
+}

--- a/app/Models/Domain/exceptions/UnauthorizedException.php
+++ b/app/Models/Domain/exceptions/UnauthorizedException.php
@@ -13,7 +13,7 @@ use Throwable;
  */
 class UnauthorizedException extends BusinessLogicException
 {
-    const ERROR_MESSAGE = 'Unauthorixed';
+    const ERROR_MESSAGE = 'Unauthorized';
 
     const ERROR_CODE = 401;
 

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Uuid;
 use App\Models\Domain\AccountEntity;
 use App\Models\Domain\AccountRepository;
 use App\Models\Domain\QiitaAccountValue;
+use App\Models\Domain\LoginSessionEntity;
 use App\Models\Domain\LoginSessionRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
@@ -104,20 +105,20 @@ class AccountScenario
     public function destroy(array $params)
     {
         if ($params['sessionId'] === null) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         }
 
         try {
             $loginSessionEntity = $this->loginSessionRepository->find($params['sessionId']);
 
             if ($loginSessionEntity->isExpired()) {
-                throw new LoginSessionExpiredException($loginSessionEntity->sessionExpiredMessage());
+                throw new LoginSessionExpiredException($loginSessionEntity->loginSessionExpiredMessage());
             }
 
             $accountEntity = $loginSessionEntity->findHasAccountEntity($this->accountRepository);
             $accountEntity->cancel($this->accountRepository, $this->loginSessionRepository);
         } catch (ModelNotFoundException $e) {
-            throw new UnauthorizedException();
+            throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         }
     }
 

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -111,7 +111,7 @@ class AccountScenario
             $loginSessionEntity = $this->loginSessionRepository->find($params['sessionId']);
 
             if ($loginSessionEntity->isExpired()) {
-                throw new LoginSessionExpiredException();
+                throw new LoginSessionExpiredException($loginSessionEntity->sessionExpiredMessage());
             }
 
             $accountEntity = $loginSessionEntity->findHasAccountEntity($this->accountRepository);

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -13,6 +13,7 @@ use App\Models\Domain\LoginSessionRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
 use App\Models\Domain\exceptions\ValidationException;
+use App\Models\Domain\exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\exceptions\AccountCreatedException;
 
@@ -96,9 +97,14 @@ class AccountScenario
      * アカウントを削除する
      *
      * @param array $params
+     * @throws UnauthorizedException
      */
     public function destroy(array $params)
     {
+        if ($params['sessionId'] === null) {
+            throw new UnauthorizedException();
+        }
+
         try {
             $loginSessionEntity = $this->loginSessionRepository->find($params['sessionId']);
 
@@ -107,7 +113,7 @@ class AccountScenario
             $accountEntity = $loginSessionEntity->findHasAccountEntity($this->accountRepository);
             $accountEntity->cancel($this->accountRepository, $this->loginSessionRepository);
         } catch (ModelNotFoundException $e) {
-            // TODO LoginSessionEntity、AccountEntityが存在しなかった場合のエラー処理を追加する
+            throw new UnauthorizedException();
         }
     }
 

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -16,6 +16,7 @@ use App\Models\Domain\exceptions\ValidationException;
 use App\Models\Domain\exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\exceptions\AccountCreatedException;
+use App\Models\Domain\exceptions\LoginSessionExpiredException;
 
 /**
  * Class AccountScenario
@@ -97,6 +98,7 @@ class AccountScenario
      * アカウントを削除する
      *
      * @param array $params
+     * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
      */
     public function destroy(array $params)
@@ -108,7 +110,9 @@ class AccountScenario
         try {
             $loginSessionEntity = $this->loginSessionRepository->find($params['sessionId']);
 
-            // TODO ログインセッションの有効期限の検証を行う
+            if ($loginSessionEntity->isExpired()) {
+                throw new LoginSessionExpiredException();
+            }
 
             $accountEntity = $loginSessionEntity->findHasAccountEntity($this->accountRepository);
             $accountEntity->cancel($this->accountRepository, $this->loginSessionRepository);

--- a/database/factories/AccountFactory.php
+++ b/database/factories/AccountFactory.php
@@ -21,9 +21,12 @@ $factory->define(App\Eloquents\AccessToken::class, function (Faker $faker) {
 });
 
 $factory->define(App\Eloquents\LoginSession::class, function (Faker $faker) {
+    $expiredOn = new \DateTime();
+    $expiredOn->add(new \DateInterval('PT1H'));
+
     return [
         'id'         => $faker->uuid(),
         'account_id' => '1',
-        'expired_on' => '2018-10-01 00:00:00'
+        'expired_on' => $expiredOn
     ];
 });

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -177,7 +177,7 @@ class AccountTest extends AbstractTestCase
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $expectedErrorCode = 401;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'Unauthorixed']);
+        $jsonResponse->assertJson(['message' => 'Unauthorized']);
         $jsonResponse->assertStatus($expectedErrorCode);
     }
 
@@ -198,7 +198,36 @@ class AccountTest extends AbstractTestCase
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $expectedErrorCode = 401;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'Unauthorixed']);
+        $jsonResponse->assertJson(['message' => 'Unauthorized']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが有効期限切れの場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionIsExpired()
+    {
+        $destroyedAccountId = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        factory(LoginSession::class)->create([
+            'id' => $loginSession,
+            'account_id' => $destroyedAccountId,
+            'expired_on' => '2018-10-01 00:00:00'
+        ]);
+
+        $jsonResponse = $this->delete(
+            '/api/accounts',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'Unauthorized']);
         $jsonResponse->assertStatus($expectedErrorCode);
     }
 

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -212,7 +212,7 @@ class AccountTest extends AbstractTestCase
         $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
 
         factory(LoginSession::class)->create([
-            'id' => $loginSession,
+            'id'         => $loginSession,
             'account_id' => $destroyedAccountId,
             'expired_on' => '2018-10-01 00:00:00'
         ]);
@@ -227,7 +227,7 @@ class AccountTest extends AbstractTestCase
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $expectedErrorCode = 401;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'Unauthorized']);
+        $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
     }
 

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -168,6 +168,42 @@ class AccountTest extends AbstractTestCase
 
     /**
      * 異常系のテスト
+     * Authorizationが存在しない場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionNull()
+    {
+        $jsonResponse = $this->delete('/api/accounts');
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'Unauthorixed']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが不正の場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionNotFound()
+    {
+        $loginSession = 'notFound-2bae-4028-b53d-0f128479e650';
+
+        $jsonResponse = $this->delete(
+            '/api/accounts',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'Unauthorixed']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+
+    /**
+     * 異常系のテスト
      * アカウント作成時のアクセストークンのバリデーション
      *
      * @param $accessToken

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -177,7 +177,7 @@ class AccountTest extends AbstractTestCase
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $expectedErrorCode = 401;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'Unauthorized']);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
     }
 
@@ -198,7 +198,7 @@ class AccountTest extends AbstractTestCase
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $expectedErrorCode = 401;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'Unauthorized']);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
     }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/39

# Doneの定義
- ログインセッションが不正だった場合にエラーが返されること

# 変更点概要

## 仕様的変更点概要
- 以下のケースにおいて、エラーレスポンスが返るように修正
  - Authorizationリクエストヘッダにログインセッションが含まれていない
  - ログインセッションがDBに存在しない
  - ログインセッションの有効期限が切れている

ログインセッションが不正のケース
```
{
  "code":401,
  "message":"セッションが不正です。再度、ログインしてください。"
}
```

ログインセッションの有効期限が切れているケース
```
{
  "code":401,
  "message":"セッションの期限が切れました。再度、ログインしてください。"
}
```

## 技術的変更点概要
`app/Models/Domain/exceptions`配下に、以下の独自例外を追加。
- UnauthorizedException
- LoginSessionExpiredException