### PR TITLE
ModelNotFoundExceptionをThrowするように修正

### DIFF
--- a/app/Infrastructure/Repositories/AccountRepository.php
+++ b/app/Infrastructure/Repositories/AccountRepository.php
@@ -100,16 +100,10 @@ class AccountRepository implements \App\Models\Domain\AccountRepository
      *
      * @param QiitaAccountValue $qiitaAccountValue
      * @return AccountEntity
-     * @throws \Exception
      */
     public function findByPermanentId(QiitaAccountValue $qiitaAccountValue): AccountEntity
     {
-        $qiitaAccount = QiitaAccount::where('qiita_account_id', $qiitaAccountValue->getPermanentId())->first();
-
-        if ($qiitaAccount === null) {
-            // TODO ModelNotFoundExceptionをThrowするように修正
-            throw new \Exception('qiitaAccountNotFoundException');
-        }
+        $qiitaAccount = QiitaAccount::where('qiita_account_id', $qiitaAccountValue->getPermanentId())->firstOrFail();
 
         $accessToken = AccessToken::where('account_id', $qiitaAccount->account_id)->first();
 

--- a/app/Infrastructure/Repositories/AccountRepository.php
+++ b/app/Infrastructure/Repositories/AccountRepository.php
@@ -105,7 +105,7 @@ class AccountRepository implements \App\Models\Domain\AccountRepository
     {
         $qiitaAccount = QiitaAccount::where('qiita_account_id', $qiitaAccountValue->getPermanentId())->firstOrFail();
 
-        $accessToken = AccessToken::where('account_id', $qiitaAccount->account_id)->first();
+        $accessToken = AccessToken::where('account_id', $qiitaAccount->account_id)->firstOrFail();
 
         $accountEntityBuilder = new AccountEntityBuilder();
         $accountEntityBuilder->setAccountId($qiitaAccount->account_id);

--- a/app/Models/Domain/AccountRepository.php
+++ b/app/Models/Domain/AccountRepository.php
@@ -32,7 +32,6 @@ interface AccountRepository
      *
      * @param QiitaAccountValue $qiitaAccountValue
      * @return AccountEntity
-     * @throws \Exception
      */
     public function findByPermanentId(QiitaAccountValue $qiitaAccountValue): AccountEntity;
 

--- a/app/Models/Domain/QiitaAccountValue.php
+++ b/app/Models/Domain/QiitaAccountValue.php
@@ -5,6 +5,8 @@
 
 namespace App\Models\Domain;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
 /**
  * Class QiitaAccountValue
  * @package App\Models\Domain
@@ -61,7 +63,7 @@ class QiitaAccountValue
     {
         try {
             return $accountRepository->findByPermanentId($this);
-        } catch (\Exception $e) {
+        } catch (ModelNotFoundException $e) {
             throw new \RuntimeException();
         }
     }
@@ -77,7 +79,7 @@ class QiitaAccountValue
         try {
             $accountRepository->findByPermanentId($this);
             return true;
-        } catch (\Exception $e) {
+        } catch (ModelNotFoundException $e) {
             return false;
         }
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/48

# Doneの定義
- Repositoryクラスで`Exception`がThrowされている箇所が`ModelNotFoundException`がThrowされるように修正されていること

# 変更点概要

## 技術的変更点概要
Eloquentの`firstOrFail`メソッドを使用し、モデルが見つからなかった場合`Illuminate\Database\Eloquent\ModelNotFoundException`がThrowされるように修正。