### PR TITLE
APIのレスポンスHeaderにX-Request-Idを追加する

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -51,14 +51,15 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth'          => \Illuminate\Auth\Middleware\Authenticate::class,
-        'auth.basic'    => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'bindings'      => \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
-        'can'           => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest'         => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'signed'        => \Illuminate\Routing\Middleware\ValidateSignature::class,
-        'throttle'      => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'cors'          => \App\Http\Middleware\Cors::class,
+        'auth'                => \Illuminate\Auth\Middleware\Authenticate::class,
+        'auth.basic'          => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'bindings'            => \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'cache.headers'       => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can'                 => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest'               => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'signed'              => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'throttle'            => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'cors'                => \App\Http\Middleware\Cors::class,
+        'xRequestId'          => \App\Http\Middleware\XRequestId::class,
     ];
 }

--- a/app/Http/Middleware/XRequestId.php
+++ b/app/Http/Middleware/XRequestId.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * XRequestId
+ */
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Ramsey\Uuid\Uuid;
+
+class XRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param $request
+     * @param Closure $next
+     * @return mixed
+     * @throws \Exception
+     */
+    public function handle($request, Closure $next)
+    {
+        $XRequestId = Uuid::uuid4();
+
+        return $next($request)
+            ->header('X-Request-Id', $XRequestId);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,7 +12,7 @@
 |
 */
 
-Route::middleware(['cors'])->group(function () {
+Route::middleware(['cors', 'xRequestId'])->group(function () {
     Route::get('weather', 'WeatherController@index');
 
     Route::options('accounts', function () {

--- a/tests/Feature/AccountTest.php
+++ b/tests/Feature/AccountTest.php
@@ -57,6 +57,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['accountId' => $expectedAccountId]);
         $jsonResponse->assertJson(['_embedded' => $expectedEmbedded]);
         $jsonResponse->assertStatus(201);
+        $jsonResponse->assertHeader('X-Request-Id');
 
         // DBのテーブルに期待した形でデータが入っているか確認する
         $idSequence = 2;
@@ -108,6 +109,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '既にアカウントの登録が完了しています。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -135,6 +137,8 @@ class AccountTest extends AbstractTestCase
         );
 
         $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+
 
         // DBのテーブルに期待した形でデータが入っているか確認する
         $this->assertDatabaseMissing('accounts', [
@@ -179,6 +183,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -200,6 +205,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -229,6 +235,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -255,6 +262,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、アカウント登録を行なってください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -299,6 +307,7 @@ class AccountTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、アカウント登録を行なってください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**

--- a/tests/Feature/LoginSessionTest.php
+++ b/tests/Feature/LoginSessionTest.php
@@ -53,6 +53,7 @@ class LoginSessionTest extends AbstractTestCase
         $accountId = 1;
         $jsonResponse->assertJson(['sessionId' => $responseObject->sessionId]);
         $jsonResponse->assertStatus(201);
+        $jsonResponse->assertHeader('X-Request-Id');
 
         // DBのテーブルに期待した形でデータが入っているか確認する
         $idSequence = 1;
@@ -100,6 +101,7 @@ class LoginSessionTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => 'アカウントが登録されていません。アカウント作成ページよりアカウントを作成してください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -126,6 +128,7 @@ class LoginSessionTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**
@@ -170,6 +173,7 @@ class LoginSessionTest extends AbstractTestCase
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
     }
 
     /**


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/17

# Doneの定義
- レスポンスHeaderにX-Request-Idが追加されていること

# 変更点概要

## 仕様的変更点概要
レスポンスHeaderにX-Request-Idを追加。

## 技術的変更点概要
`app/Http/Middleware`にミドルウェア`XRequestId.php`を作成。
Uuidを生成し、リクエストヘッダーに値を追加している。