### PR TITLE
バリデーションのビジネスロジックをドメイン層に移動

### DIFF
--- a/app/Models/Domain/AccountSpecification.php
+++ b/app/Models/Domain/AccountSpecification.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * AccountSpecification
+ */
+
+namespace App\Models\Domain;
+
+/**
+ * Class AccountSpecification
+ * @package App\Models\Domain
+ */
+class AccountSpecification
+{
+    /**
+     * アカウント作成可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canCreate(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'accessToken' => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
+            'permanentId' => 'required|integer|min:1|max:4294967294',
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
+}

--- a/app/Models/Domain/LoginSessionSpecification.php
+++ b/app/Models/Domain/LoginSessionSpecification.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * LoginSessionSpecification
+ */
+
+namespace App\Models\Domain;
+
+/**
+ * Class LoginSessionSpecification
+ * @package App\Models\Domain
+ */
+class LoginSessionSpecification
+{
+    /**
+     * ログイン可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canCreate(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'accessToken' => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
+            'permanentId' => 'required|integer|min:1|max:4294967294',
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/45

# Doneの定義
- アプリケーション層に定義されているバリデーションのビジネスロジックがビジネス層に移動されていること

# 変更点概要

## 技術的変更点概要
仕様クラスを作成し、バリデーションロジックをドメイン層に移動した。
- AccountSpecification
- LoginSessionSpecification

それぞれ、アカウント/ログインセッションの作成が可能かどうかを判定する`canCreate`メソッドを作成している。
名前が`canCreate`となっているが、
バリデーションエラーメッセージを取得する必要があるため、配列を戻り値とした。