### PR TITLE
カテゴリのDBへの登録処理を作成する

### DIFF
--- a/app/Infrastructure/Repositories/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/CategoryRepository.php
@@ -5,6 +5,8 @@
 
 namespace App\Infrastructure\Repositories;
 
+use App\Eloquents\Category;
+use App\Eloquents\CategoryName;
 use App\Models\Domain\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryNameValue;
@@ -18,9 +20,42 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
 {
     public function create(AccountEntity $accountEntity, CategoryNameValue $categoryNameValue): CategoryEntity
     {
+        $categoryId = $this->saveCategories($accountEntity->getAccountId());
+        $this->saveCategoriesNames($categoryId, $categoryNameValue);
+
         $categoryEntityBuilder = new CategoryEntityBuilder();
-        $categoryEntityBuilder->setId('1');
+        $categoryEntityBuilder->setId($categoryId);
         $categoryEntityBuilder->setCategoryNameValue($categoryNameValue);
         return $categoryEntityBuilder->build();
+    }
+
+    /**
+     * categories テーブルにデータを保存する
+     *
+     * @param int $accountId
+     * @return int
+     */
+    private function saveCategories(int $accountId): int
+    {
+        $category = new Category();
+        $category->account_id = $accountId;
+        $category->save();
+        $categoryId = $category->getAttribute('id');
+
+        return $categoryId;
+    }
+
+    /**
+     * categories_names テーブルにデータを保存する
+     *
+     * @param int $categoryId
+     * @param CategoryNameValue $categoryNameValue
+     */
+    private function saveCategoriesNames(int $categoryId, CategoryNameValue $categoryNameValue)
+    {
+        $categoryName = new CategoryName();
+        $categoryName->category_id = $categoryId;
+        $categoryName->name = $categoryNameValue->getName();
+        $categoryName->save();
     }
 }

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -14,7 +14,7 @@ class CategoryEntity
     /**
      * カテゴリID
      *
-     * @var string
+     * @var int
      */
     private $Id;
 
@@ -32,9 +32,9 @@ class CategoryEntity
     }
 
     /**
-     * @return string
+     * @return int
      */
-    public function getId(): string
+    public function getId(): int
     {
         return $this->Id;
     }

--- a/app/Models/Domain/Category/CategoryEntityBuilder.php
+++ b/app/Models/Domain/Category/CategoryEntityBuilder.php
@@ -14,7 +14,7 @@ class CategoryEntityBuilder
     /**
      * カテゴリID
      *
-     * @var string
+     * @var int
      */
     private $Id;
 
@@ -26,17 +26,17 @@ class CategoryEntityBuilder
     private $categoryNameValue;
 
     /**
-     * @return string
+     * @return int
      */
-    public function getId(): string
+    public function getId(): int
     {
         return $this->Id;
     }
 
     /**
-     * @param string $Id
+     * @param int $Id
      */
-    public function setId(string $Id): void
+    public function setId(int $Id): void
     {
         $this->Id = $Id;
     }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -64,6 +64,8 @@ class CategoryScenario
     public function create(array $params): array
     {
         try {
+            // TODO バリデーションを追加する
+
             if ($params['sessionId'] === null) {
                 throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
             }
@@ -76,7 +78,7 @@ class CategoryScenario
 
             $accountEntity = $loginSessionEntity->findHasAccountEntity($this->accountRepository);
 
-            // \DB::beginTransaction();
+            \DB::beginTransaction();
 
             $categoryNameValue = new CategoryNameValue($params['name']);
 
@@ -89,11 +91,11 @@ class CategoryScenario
 
             return $categories;
 
-            // \DB::commit();
+            \DB::commit();
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         } catch (\PDOException $e) {
-            // \DB::rollBack();
+            \DB::rollBack();
             throw $e;
         }
     }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -84,13 +84,6 @@ class CategoryScenario
 
             $categoryEntity = $this->categoryRepository->create($accountEntity, $categoryNameValue);
 
-            $categories = [
-                'categoryId'   => $categoryEntity->getId(),
-                'name'         => $categoryEntity->getCategoryNameValue()->getName()
-            ];
-
-            return $categories;
-
             \DB::commit();
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
@@ -98,5 +91,12 @@ class CategoryScenario
             \DB::rollBack();
             throw $e;
         }
+
+        $categories = [
+            'categoryId'   => $categoryEntity->getId(),
+            'name'         => $categoryEntity->getCategoryNameValue()->getName()
+        ];
+
+        return $categories;
     }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(\App\Eloquents\Category::class, function (Faker $faker) {
+    return [
+        'account_id'       => '1',
+    ];
+});
+
+$factory->define(\App\Eloquents\CategoryName::class, function (Faker $faker) {
+    return [
+        'category_id'       => '1',
+        'name'              => $faker->word,
+    ];
+});

--- a/tests/Feature/AbstractTestCase.php
+++ b/tests/Feature/AbstractTestCase.php
@@ -7,8 +7,10 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Eloquents\Account;
+use App\Eloquents\Category;
 use Tests\CreatesApplication;
 use App\Eloquents\AccessToken;
+use App\Eloquents\CategoryName;
 use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
 
@@ -29,6 +31,8 @@ abstract class AbstractTestCase extends TestCase
         LoginSession::truncate();
         AccessToken::truncate();
         QiitaAccount::truncate();
+        Category::truncate();
+        CategoryName::truncate();
         \DB::statement('SET FOREIGN_KEY_CHECKS=1');
     }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/52

# Doneの定義
- カテゴリがDBに登録されていること

# 変更点概要

## 仕様的変更点概要
データベースへの保存処理を追加。

## 技術的変更点概要
`CategoryRepository`に、Eloquentを利用したデータベースへの保存処理を追加。
テストクラスにも、データベースの登録処理を確認するテストケースを追加している。