### PR TITLE
カテゴリ取得APIのIFを定義する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -30,6 +30,43 @@ class CategoryController extends Controller
         $this->categoryScenario = $categoryScenario;
     }
 
+    /**
+     * カテゴリ一覧を取得する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $categories = [
+
+            [
+                'categoryId'   => 1,
+                'name'         => 'カテゴリ名1'
+
+            ],
+            [
+                'categoryId'   => 2,
+                'name'         => 'カテゴリ名2'
+            ],
+            [
+                'categoryId'   => 3,
+                'name'         => 'カテゴリ名3'
+            ]
+        ];
+
+        return response()->json($categories)->setStatusCode(200);
+    }
+
+
+    /**
+     * カテゴリを作成する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
+     * @throws \App\Models\Domain\exceptions\UnauthorizedException
+     */
     public function create(Request $request): JsonResponse
     {
         $requestArray = $request->json()->all();
@@ -41,8 +78,8 @@ class CategoryController extends Controller
 
         $params = array_merge($params, $requestArray);
 
-        $categories = $this->categoryScenario->create($params);
+        $category = $this->categoryScenario->create($params);
 
-        return response()->json($categories)->setStatusCode(201);
+        return response()->json($category)->setStatusCode(201);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,5 +33,7 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
         return response()->json();
     });
 
+    Route::get('categories', 'CategoryController@index');
+
     Route::post('categories', 'CategoryController@create');
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/53

# Doneの定義
- カテゴリ取得APIのIFが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴリ作成APIのIFを定義
`GET api/categories`

リクエスト
```
curl -X GET -kv \
-H "Authorization: Bearer e28b5056-6b1b-4f91-a2b5-fdea13f327cb" \
http://127.0.0.1/api/categories
```

HTTPレスポンスHeader
```
HTTP/1.1 200 OK
Content-Type: application/json
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```

HTTPレスポンスBody
```
[
  {
    "categoryId":1,
    "name":"カテゴリ名1" 
  },
  {
    "categoryId":2,
    "name":"カテゴリ名2"
  },
  {
    "categoryId":3,
    "name":"カテゴリ名3"
  }
]
```

## 技術的変更点概要
ルーティングを設定
