### PR TITLE
退会APIにカテゴリを削除する処理を追加する

### DIFF
--- a/app/Infrastructure/Repositories/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/CategoryRepository.php
@@ -73,7 +73,7 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
             ->join('categories_names', 'categories.id', '=', 'categories_names.category_id')
             ->get();
 
-        $categoryEntityCollection = $categories->map(function ($category): CategoryEntity {
+        $categoryEntityCollection = $categories->map(function (Category $category): CategoryEntity {
             return $this->buildCategoryEntity($category->toArray());
         });
 
@@ -96,5 +96,20 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
         $categoryEntityBuilder->setCategoryNameValue($categoryNameVale);
 
         return $categoryEntityBuilder->build();
+    }
+
+    /**
+     * アカウントに紐づくカテゴリを全て削除する
+     *
+     * @param string $accountId
+     */
+    public function destroyAll(string $accountId)
+    {
+        $categories = Category::where('account_id', $accountId);
+
+        $categoryIdList = $categories->get()->pluck('id');
+        CategoryName::whereIn('category_id', $categoryIdList)->delete();
+
+        $categories->delete();
     }
 }

--- a/app/Models/Domain/AccountEntity.php
+++ b/app/Models/Domain/AccountEntity.php
@@ -5,6 +5,8 @@
 
 namespace App\Models\Domain;
 
+use App\Models\Domain\Category\CategoryRepository;
+
 /**
  * Class AccountEntity
  * @package App\Models\Domain
@@ -90,9 +92,14 @@ class AccountEntity
      *
      * @param AccountRepository $accountRepository
      * @param LoginSessionRepository $loginSessionRepository
+     * @param CategoryRepository $categoryRepository
      */
-    public function cancel(AccountRepository $accountRepository, LoginSessionRepository $loginSessionRepository)
-    {
+    public function cancel(
+        AccountRepository $accountRepository,
+        LoginSessionRepository $loginSessionRepository,
+        CategoryRepository $categoryRepository
+    ) {
+        $categoryRepository->destroyAll($this->getAccountId());
         $loginSessionRepository->destroyLoginSessions($this->getAccountId());
         $accountRepository->destroyAccessToken($this->getAccountId());
         $accountRepository->destroyQiitaAccount($this->getAccountId());

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -29,4 +29,11 @@ interface CategoryRepository
      * @return CategoryEntities
      */
     public function search(AccountEntity $accountEntity): CategoryEntities;
+
+    /**
+     * アカウントに紐づくカテゴリを全て削除する
+     *
+     * @param string $accountId
+     */
+    public function destroyAll(string $accountId);
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -51,7 +51,8 @@ class AppServiceProvider extends ServiceProvider
             function () {
                 return new AccountScenario(
                     $this->app->make(AccountRepository::class),
-                    $this->app->make(LoginSessionRepository::class)
+                    $this->app->make(LoginSessionRepository::class),
+                    $this->app->make(CategoryRepository::class)
                 );
             }
         );

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -14,6 +14,7 @@ use App\Models\Domain\AccountSpecification;
 use App\Models\Domain\LoginSessionRepository;
 use App\Models\Domain\QiitaAccountValueBuilder;
 use App\Models\Domain\LoginSessionEntityBuilder;
+use App\Models\Domain\Category\CategoryRepository;
 use App\Models\Domain\Exceptions\ValidationException;
 use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -40,15 +41,28 @@ class AccountScenario
      * @var
      */
     private $loginSessionRepository;
+
+    /**
+     * CategoryRepository
+     *
+     * @var
+     */
+    private $categoryRepository;
+
     /**
      * AccountScenario constructor.
      * @param AccountRepository $accountRepository
      * @param LoginSessionRepository $loginSessionRepository
+     * @param CategoryRepository $categoryRepository
      */
-    public function __construct(AccountRepository $accountRepository, LoginSessionRepository $loginSessionRepository)
-    {
+    public function __construct(
+        AccountRepository $accountRepository,
+        LoginSessionRepository $loginSessionRepository,
+        CategoryRepository $categoryRepository
+    ) {
         $this->accountRepository = $accountRepository;
         $this->loginSessionRepository = $loginSessionRepository;
+        $this->categoryRepository = $categoryRepository;
     }
 
     /**
@@ -132,7 +146,7 @@ class AccountScenario
 
             \DB::beginTransaction();
 
-            $accountEntity->cancel($this->accountRepository, $this->loginSessionRepository);
+            $accountEntity->cancel($this->accountRepository, $this->loginSessionRepository, $this->categoryRepository);
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/tests/Feature/AccountCreateTest.php
+++ b/tests/Feature/AccountCreateTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AccountIndexTest
+ * AccountCreateTest
  */
 
 namespace Tests\Feature;
@@ -12,10 +12,10 @@ use App\Eloquents\QiitaAccount;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
- * Class AccountIndexTest
+ * Class AccountCreateTest
  * @package Tests
  */
-class AccountIndexTest extends AbstractTestCase
+class AccountCreateTest extends AbstractTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Feature/AccountDestroyTest.php
+++ b/tests/Feature/AccountDestroyTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * AccountDestroyTest
+ */
+
+namespace Tests\Feature;
+
+use App\Eloquents\Account;
+use App\Eloquents\AccessToken;
+use App\Eloquents\LoginSession;
+use App\Eloquents\QiitaAccount;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class AccountDestroyTest
+ * @package Tests\Feature
+ */
+class AccountDestroyTest extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $accounts = factory(Account::class)->create();
+        $accounts->each(function ($account) {
+            factory(QiitaAccount::class)->create(['account_id' => $account->id]);
+            factory(AccessToken::class)->create(['account_id' => $account->id]);
+            factory(LoginSession::class)->create(['account_id' => $account->id]);
+        });
+    }
+
+    /**
+     * 正常系のテスト
+     * アカウントが削除できること
+     */
+    public function testSuccessDestroy()
+    {
+        $destroyedAccountId = 1;
+        $accountId = 2;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $destroyedAccountId, ]);
+
+        factory(Account::class)->create();
+        factory(QiitaAccount::class)->create(['qiita_account_id' => 2, 'account_id' => $accountId]);
+        factory(AccessToken::class)->create(['account_id' => $accountId]);
+        factory(LoginSession::class)->create(['account_id' => $accountId]);
+
+        $jsonResponse = $this->delete(
+            '/api/accounts',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+
+        );
+
+        $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+
+
+        // DBのテーブルに期待した形でデータが入っているか確認する
+        $this->assertDatabaseMissing('accounts', [
+            'id'           => $destroyedAccountId,
+        ]);
+        $this->assertDatabaseHas('accounts', [
+            'id'       => $accountId,
+        ]);
+
+        $this->assertDatabaseMissing('accounts_qiita_accounts', [
+            'account_id'       => $destroyedAccountId,
+        ]);
+        $this->assertDatabaseHas('accounts_qiita_accounts', [
+            'account_id'       => $accountId,
+        ]);
+
+        $this->assertDatabaseMissing('accounts_access_tokens', [
+            'account_id'   => $destroyedAccountId,
+        ]);
+        $this->assertDatabaseHas('accounts_access_tokens', [
+            'account_id'       => $accountId,
+        ]);
+
+        $this->assertDatabaseMissing('login_sessions', [
+            'account_id'   => $destroyedAccountId,
+        ]);
+        $this->assertDatabaseHas('login_sessions', [
+            'account_id'   => $accountId,
+        ]);
+    }
+
+    /**
+     * 異常系のテスト
+     * Authorizationが存在しない場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionNull()
+    {
+        $jsonResponse = $this->delete('/api/accounts');
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが不正の場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionNotFound()
+    {
+        $loginSession = 'notFound-2bae-4028-b53d-0f128479e650';
+
+        $jsonResponse = $this->delete(
+            '/api/accounts',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが有効期限切れの場合エラーとなること
+     */
+    public function testErrorDestroyLoginSessionIsExpired()
+    {
+        $destroyedAccountId = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        factory(LoginSession::class)->create([
+            'id'         => $loginSession,
+            'account_id' => $destroyedAccountId,
+            'expired_on' => '2018-10-01 00:00:00'
+        ]);
+
+        $jsonResponse = $this->delete(
+            '/api/accounts',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+}

--- a/tests/Feature/AccountIndexTest.php
+++ b/tests/Feature/AccountIndexTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AccountTest
+ * AccountIndexTest
  */
 
 namespace Tests\Feature;
@@ -12,10 +12,10 @@ use App\Eloquents\QiitaAccount;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
- * Class AccountTest
+ * Class AccountIndexTest
  * @package Tests
  */
-class AccountTest extends AbstractTestCase
+class AccountIndexTest extends AbstractTestCase
 {
     use RefreshDatabase;
 
@@ -108,132 +108,6 @@ class AccountTest extends AbstractTestCase
         $expectedErrorCode = 409;
         $jsonResponse->assertJson(['code' => $expectedErrorCode]);
         $jsonResponse->assertJson(['message' => '既にアカウントの登録が完了しています。']);
-        $jsonResponse->assertStatus($expectedErrorCode);
-        $jsonResponse->assertHeader('X-Request-Id');
-    }
-
-    /**
-     * 正常系のテスト
-     * アカウントが削除できること
-     */
-    public function testSuccessDestroy()
-    {
-        $destroyedAccountId = 1;
-        $accountId = 2;
-        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
-
-        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $destroyedAccountId, ]);
-
-        factory(Account::class)->create();
-        factory(QiitaAccount::class)->create(['qiita_account_id' => 2, 'account_id' => $accountId]);
-        factory(AccessToken::class)->create(['account_id' => $accountId]);
-        factory(LoginSession::class)->create(['account_id' => $accountId]);
-
-        $jsonResponse = $this->delete(
-            '/api/accounts',
-            [],
-            ['Authorization' => 'Bearer '.$loginSession]
-
-        );
-
-        $jsonResponse->assertStatus(204);
-        $jsonResponse->assertHeader('X-Request-Id');
-
-
-        // DBのテーブルに期待した形でデータが入っているか確認する
-        $this->assertDatabaseMissing('accounts', [
-            'id'           => $destroyedAccountId,
-        ]);
-        $this->assertDatabaseHas('accounts', [
-            'id'       => $accountId,
-        ]);
-
-        $this->assertDatabaseMissing('accounts_qiita_accounts', [
-            'account_id'       => $destroyedAccountId,
-        ]);
-        $this->assertDatabaseHas('accounts_qiita_accounts', [
-            'account_id'       => $accountId,
-        ]);
-
-        $this->assertDatabaseMissing('accounts_access_tokens', [
-            'account_id'   => $destroyedAccountId,
-        ]);
-        $this->assertDatabaseHas('accounts_access_tokens', [
-            'account_id'       => $accountId,
-        ]);
-
-        $this->assertDatabaseMissing('login_sessions', [
-            'account_id'   => $destroyedAccountId,
-        ]);
-        $this->assertDatabaseHas('login_sessions', [
-            'account_id'   => $accountId,
-        ]);
-    }
-
-    /**
-     * 異常系のテスト
-     * Authorizationが存在しない場合エラーとなること
-     */
-    public function testErrorDestroyLoginSessionNull()
-    {
-        $jsonResponse = $this->delete('/api/accounts');
-
-        // 実際にJSONResponseに期待したデータが含まれているか確認する
-        $expectedErrorCode = 401;
-        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
-        $jsonResponse->assertStatus($expectedErrorCode);
-        $jsonResponse->assertHeader('X-Request-Id');
-    }
-
-    /**
-     * 異常系のテスト
-     * ログインセッションが不正の場合エラーとなること
-     */
-    public function testErrorDestroyLoginSessionNotFound()
-    {
-        $loginSession = 'notFound-2bae-4028-b53d-0f128479e650';
-
-        $jsonResponse = $this->delete(
-            '/api/accounts',
-            [],
-            ['Authorization' => 'Bearer '.$loginSession]
-        );
-
-        // 実際にJSONResponseに期待したデータが含まれているか確認する
-        $expectedErrorCode = 401;
-        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
-        $jsonResponse->assertStatus($expectedErrorCode);
-        $jsonResponse->assertHeader('X-Request-Id');
-    }
-
-    /**
-     * 異常系のテスト
-     * ログインセッションが有効期限切れの場合エラーとなること
-     */
-    public function testErrorDestroyLoginSessionIsExpired()
-    {
-        $destroyedAccountId = 1;
-        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
-
-        factory(LoginSession::class)->create([
-            'id'         => $loginSession,
-            'account_id' => $destroyedAccountId,
-            'expired_on' => '2018-10-01 00:00:00'
-        ]);
-
-        $jsonResponse = $this->delete(
-            '/api/accounts',
-            [],
-            ['Authorization' => 'Bearer '.$loginSession]
-
-        );
-
-        // 実際にJSONResponseに期待したデータが含まれているか確認する
-        $expectedErrorCode = 401;
-        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-        $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/63

# Doneの定義
- 退会APIにカテゴリを削除する処理が追加されていること

# 変更点概要

## 仕様的変更点概要
退会時にアカウントに紐づくカテゴリを削除する処理を追加

## 技術的変更点概要
CategoryRepositoryに、アカウントIDから`categories`、`categories_names`テーブルのデータを削除する処理を追加。
これで、画面からの退会処理が可能となった。

また、テストファイルを`AccountCreateTest`と`AccountDestroyTest`に分割した。