### PR TITLE
カテゴリ変更APIのIFを定義する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -73,4 +73,25 @@ class CategoryController extends Controller
 
         return response()->json($category)->setStatusCode(201);
     }
+
+    /**
+     * カテゴリを更新する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function update(Request $request): JsonResponse
+    {
+        $categoryId = $request->id;
+        $requestArray = $request->json()->all();
+
+        // TODO カテゴリを更新する
+
+        $category = [
+            'categoryId'   => $categoryId,
+            'name'         => $requestArray['name']
+        ];
+
+        return response()->json($category)->setStatusCode(200);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,4 +36,6 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
     Route::get('categories', 'CategoryController@index');
 
     Route::post('categories', 'CategoryController@create');
+
+    Route::patch('categories/{id}', 'CategoryController@update');
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/54

# Doneの定義
- カテゴリ変更APIのIFが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴリ作成APIのIFを定義
`PATCH api/categories/{catgoryId}`

リクエスト
```
curl -X PATCH -kv \
-H "Content-Type: application/json" \
-H "Authorization: Bearer d88f975a-abbb-454c-bf6c-b218fc9b9a67" \
-d \
'
{
  "name": "編集したカテゴリ名"
}
' \
http://127.0.0.1/api/categories/12
```

HTTPレスポンスHeader
```
HTTP/1.1 200 OK
Content-Type: application/json
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```

HTTPレスポンスBody
```
{
  "categoryId": "categoryID",
  "name": "保存したcategory名",
}
```

## 技術的変更点概要
ルーティングを設定
