### PR TITLE
例外処理を作成する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -79,6 +79,7 @@ class CategoryController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
      * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      * @throws \App\Models\Domain\exceptions\UnauthorizedException
      */

--- a/app/Http/Middleware/Cors.php
+++ b/app/Http/Middleware/Cors.php
@@ -17,7 +17,7 @@ class Cors
     {
         return $next($request)
             ->header('Access-Control-Allow-Origin', env('CORS_ORIGIN'))
-            ->header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+            ->header('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
             ->header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
     }
 }

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -46,4 +46,14 @@ class CategoryEntity
     {
         return $this->categoryNameValue;
     }
+
+    /**
+     * カテゴリが作成されていなかった場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function categoryNotFoundMessage(): string
+    {
+        return '不正なリクエストが行われました。';
+    }
 }

--- a/app/Models/Domain/Exceptions/CategoryNotFoundException.php
+++ b/app/Models/Domain/Exceptions/CategoryNotFoundException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CategoryNotFoundException
+ */
+
+namespace App\Models\Domain\Exceptions;
+
+use Throwable;
+
+/**
+ * Class CategoryNotFoundException
+ * @package App\Models\Domain\Exceptions
+ */
+class CategoryNotFoundException extends BusinessLogicException
+{
+    const ERROR_MESSAGE = 'Not Found';
+
+    const ERROR_CODE = 404;
+
+    /**
+     * CategoryNotFoundException constructor.
+     * @param string $message
+     * @param Throwable|null $previous
+     */
+    public function __construct(
+        string $message = self::ERROR_MESSAGE,
+        Throwable $previous = null
+    ) {
+        parent::__construct(
+            $message,
+            self::ERROR_CODE,
+            $previous
+        );
+    }
+}

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -8,11 +8,13 @@ namespace App\Services;
 use App\Models\Domain\AccountRepository;
 use App\Models\Domain\LoginSessionEntity;
 use App\Models\Domain\LoginSessionRepository;
+use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryNameValue;
 use App\Models\Domain\Category\CategoryRepository;
 use App\Models\Domain\Category\CategoryEntityBuilder;
 use App\Models\Domain\exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Models\Domain\Exceptions\CategoryNotFoundException;
 use App\Models\Domain\exceptions\LoginSessionExpiredException;
 
 class CategoryScenario
@@ -131,6 +133,7 @@ class CategoryScenario
      *
      * @param array $params
      * @return array
+     * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
      */
@@ -161,7 +164,7 @@ class CategoryScenario
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {
-            // TODO カテゴリが見つからなかった場合のエラー処理
+            throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
         } catch (\PDOException $e) {
             \DB::rollBack();
             throw $e;

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
 
     Route::post('login-sessions', 'LoginSessionController@create');
 
-    Route::options('categories', function () {
+    Route::options('categories/{id?}', function () {
         return response()->json();
     });
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/54

# Doneの定義
- 他のアカウントのカテゴリを更新しようとした場合のエラーとなること

# 変更点概要

## 仕様的変更点概要
- 他のアカウントのカテゴリを更新しようとした場合、以下のエラーメッセージを表示
```
不正なリクエストが行われました。
```

## 技術的変更点概要
- CORSに`PATCH`のリクエストを許可するように設定
- 他のアカウントのカテゴリを更新しようとした場合(カテゴリがアカウントに紐づいていない)のエラー処理を追加
- 上記のテストケースも追加