### PR TITLE
カラムの最大値を変更する

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Services\AccountScenario;
 use App\Services\CategoryScenario;
 use App\Services\LoginSessionScenario;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use App\Models\Domain\AccountRepository;
 use App\Models\Domain\LoginSessionRepository;
@@ -19,7 +20,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 
     /**

--- a/database/migrations/2018_10_02_070100_create_accounts_qiita_accounts_table.php
+++ b/database/migrations/2018_10_02_070100_create_accounts_qiita_accounts_table.php
@@ -17,7 +17,7 @@ class CreateAccountsQiitaAccountsTable extends Migration
         Schema::create('accounts_qiita_accounts', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('account_id');
-            $table->string('qiita_account_id', 255);
+            $table->string('qiita_account_id');
             $table->unsignedInteger('lock_version')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));

--- a/database/migrations/2018_10_02_070854_create_accounts_access_tokens_table.php
+++ b/database/migrations/2018_10_02_070854_create_accounts_access_tokens_table.php
@@ -17,7 +17,7 @@ class CreateAccountsAccessTokensTable extends Migration
         Schema::create('accounts_access_tokens', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('account_id');
-            $table->string('access_token', 255);
+            $table->string('access_token');
             $table->unsignedInteger('lock_version')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));

--- a/database/migrations/2018_10_02_072202_create_login_sessions_table.php
+++ b/database/migrations/2018_10_02_072202_create_login_sessions_table.php
@@ -15,7 +15,7 @@ class CreateLoginSessionsTable extends Migration
     public function up()
     {
         Schema::create('login_sessions', function (Blueprint $table) {
-            $table->string('id', 255);
+            $table->string('id');
             $table->unsignedInteger('account_id');
             $table->dateTime('expired_on');
             $table->unsignedInteger('lock_version')->default(0);

--- a/database/migrations/2018_11_13_005301_create_categories_names_table.php
+++ b/database/migrations/2018_11_13_005301_create_categories_names_table.php
@@ -16,7 +16,7 @@ class CreateCategoriesNamesTable extends Migration
         Schema::create('categories_names', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('category_id');
-            $table->string('name', 255);
+            $table->string('name');
             $table->unsignedInteger('lock_version')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/80

# Doneの定義
- カラムの最大値を変更し、767bytes以上の文字列が入らないようになっていること

# 変更点概要

## 仕様的変更点概要
- カラムの最大値を191文字に修正

## 技術的変更点概要
- AppServiceProviderにカラムの長さを191文字に定義する処理を追加