### PR TITLE
カテゴリ作成APIのバリデーションを作成する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -35,8 +35,8 @@ class CategoryController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
-     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
-     * @throws \App\Models\Domain\exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      */
     public function index(Request $request): JsonResponse
     {
@@ -55,8 +55,9 @@ class CategoryController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
      * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
-     * @throws \App\Models\Domain\exceptions\UnauthorizedException
      */
     public function create(Request $request): JsonResponse
     {
@@ -80,8 +81,8 @@ class CategoryController extends Controller
      * @param Request $request
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
-     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
-     * @throws \App\Models\Domain\exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      */
     public function update(Request $request): JsonResponse
     {

--- a/app/Models/Domain/Category/CategoryNameValue.php
+++ b/app/Models/Domain/Category/CategoryNameValue.php
@@ -34,4 +34,14 @@ class CategoryNameValue
     {
         return $this->name;
     }
+
+    /**
+     * カテゴリ名のバリデーションエラー時に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function nameValidationErrorMessage(): string
+    {
+        return 'カテゴリ名は最大50文字です。カテゴリ名を短くしてください。';
+    }
 }

--- a/app/Models/Domain/Category/CategorySpecification.php
+++ b/app/Models/Domain/Category/CategorySpecification.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CategorySpecification
+ */
+
+namespace App\Models\Domain\Category;
+
+/**
+ * Class CategorySpecification
+ * @package App\Models\Domain\Category
+ */
+class CategorySpecification
+{
+    /**
+     * CategoryNameValue が作成可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canCreateCategoryNameValue(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'name' => 'required|max:50',
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
+}

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -12,7 +12,7 @@ use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryNameValue;
 use App\Models\Domain\Category\CategoryRepository;
 use App\Models\Domain\Category\CategoryEntityBuilder;
-use App\Models\Domain\exceptions\UnauthorizedException;
+use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\Exceptions\CategoryNotFoundException;
 use App\Models\Domain\exceptions\LoginSessionExpiredException;

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -12,6 +12,8 @@ use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryNameValue;
 use App\Models\Domain\Category\CategoryRepository;
 use App\Models\Domain\Category\CategoryEntityBuilder;
+use App\Models\Domain\Category\CategorySpecification;
+use App\Models\Domain\Exceptions\ValidationException;
 use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\Exceptions\CategoryNotFoundException;
@@ -65,11 +67,15 @@ class CategoryScenario
      * @return array
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
+     * @throws ValidationException
      */
     public function create(array $params): array
     {
         try {
-            // TODO バリデーションを追加する
+            $errors = CategorySpecification::canCreateCategoryNameValue($params);
+            if ($errors) {
+                throw new ValidationException(CategoryNameValue::nameValidationErrorMessage(), $errors);
+            }
 
             $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
 

--- a/tests/Feature/CategoryCreateTest.php
+++ b/tests/Feature/CategoryCreateTest.php
@@ -145,4 +145,47 @@ class CategoryCreateTest extends AbstractTestCase
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
+
+    /**
+     * 異常系のテスト
+     * カテゴリ作成時のカテゴリ名のバリデーション
+     *
+     * @param $categoryName
+     * @dataProvider categoryNameProvider
+     */
+    public function testErrorCreateValidation($categoryName)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        $jsonResponse = $this->postJson(
+            '/api/categories',
+            ['name'          => $categoryName],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'カテゴリ名は最大50文字です。カテゴリ名を短くしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * カテゴリ名のデータプロバイダ
+     *
+     * @return array
+     */
+    public function categoryNameProvider()
+    {
+        return [
+            'emptyString'            => [''],
+            'null'                   => [null],
+            'emptyArray'             => [[]],
+            'tooLongLength'          => ['111111111122222222223333333333444444444455555555556'], //51文字
+            'multiByteTooLongLength' => ['テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテス🐱'] //51文字
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/68

# Doneの定義
- バリデーションが作成されていること
- バリデーションエラーの場合、エラーレスポンスが返っていること

# スクリーンショット
50文字まで入力した場合のイメージ
<img width="300" alt="2018-12-09 17 33 12" src="https://user-images.githubusercontent.com/32682645/49695077-910f3200-fbd8-11e8-8d43-d096dc8a620b.png">

# 変更点概要

## 仕様的変更点概要
カテゴリ名の最大値を50文字に設定。
51文字以上入力された場合、下記のエラーメッセージを返す。
```
カテゴリ名は最大50文字です。カテゴリ名を短くしてください。
```

## 技術的変更点概要
`app/Models/Domain/Category/CategorySpecification.php`を作成し、バリデーション処理を追加。