### PR TITLE
カテゴリ編集APIのバリデーションを作成する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -81,8 +81,9 @@ class CategoryController extends Controller
      * @param Request $request
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
-     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
+     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      */
     public function update(Request $request): JsonResponse
     {

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -48,6 +48,16 @@ class CategoryEntity
     }
 
     /**
+     * カテゴリIDのバリデーションエラー時に利用するメッセージ
+     *
+     * @return string
+     */
+    public static function categoryIdValidationErrorMessage(): string
+    {
+        return '不正なリクエストが行われました。';
+    }
+
+    /**
      * カテゴリが作成されていなかった場合に使用するメッセージ
      *
      * @return string

--- a/app/Models/Domain/Category/CategorySpecification.php
+++ b/app/Models/Domain/Category/CategorySpecification.php
@@ -28,4 +28,22 @@ class CategorySpecification
         }
         return [];
     }
+
+    /**
+     * CategoryEntity が作成可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canSetCategoryEntityId(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'id'   => 'required|integer|min:1|max:18446744073709551615' // 符号無しBIGINTの最大値
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
 }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -142,6 +142,7 @@ class CategoryScenario
      * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
+     * @throws ValidationException
      */
     public function update(array $params): array
     {
@@ -154,7 +155,15 @@ class CategoryScenario
         }
 
         try {
-            // TODO nameのバリデーションを追加
+            $errors = CategorySpecification::canSetCategoryEntityId($params);
+            if ($errors) {
+                throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
+            }
+
+            $errors = CategorySpecification::canCreateCategoryNameValue($params);
+            if ($errors) {
+                throw new ValidationException(CategoryNameValue::nameValidationErrorMessage(), $errors);
+            }
 
             $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 

--- a/tests/Feature/CategoryUpdateTest.php
+++ b/tests/Feature/CategoryUpdateTest.php
@@ -199,4 +199,98 @@ class CategoryUpdateTest extends AbstractTestCase
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
+
+    /**
+     * 異常系のテスト
+     * カテゴリ更新時のカテゴリ名のバリデーション
+     *
+     * @param $categoryName
+     * @dataProvider categoryNameProvider
+     */
+    public function testErrorNameValidation($categoryName)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $categoryId = 1;
+
+        $jsonResponse = $this->patchJson(
+            '/api/categories/'. $categoryId,
+            ['name'          => $categoryName],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'カテゴリ名は最大50文字です。カテゴリ名を短くしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * カテゴリ名のデータプロバイダ
+     *
+     * @return array
+     */
+    public function categoryNameProvider()
+    {
+        return [
+            'emptyString'            => [''],
+            'null'                   => [null],
+            'emptyArray'             => [[]],
+            'tooLongLength'          => ['111111111122222222223333333333444444444455555555556'], //51文字
+            'multiByteTooLongLength' => ['テストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテストテス🐱'] //51文字
+        ];
+    }
+
+    /**
+     * 異常系のテスト
+     * カテゴリ更新時のカテゴリIDのバリデーション
+     *
+     * @param $categoryId
+     * @dataProvider categoryIdProvider
+     */
+    public function testErrorCategoryIdValidation($categoryId)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $categoryName = 'テストカテゴリ名';
+
+        $jsonResponse = $this->patchJson(
+            '/api/categories/'. $categoryId,
+            ['name'          => $categoryName],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * カテゴリIDのデータプロバイダ
+     *
+     * @return array
+     */
+    public function categoryIdProvider()
+    {
+        // カテゴリIDが設定されていない場合はルーティングされないので考慮しない
+        return [
+            'string'             => ['a'],
+            'symbol'             => ['1@'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [18446744073709551615],
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/77

# Doneの定義
- バリデーションが作成されていること
- バリデーションエラーの場合、エラーレスポンスが返っていること

# 変更点概要

## 仕様的変更点概要
カテゴリIDとカテゴリ名のバリデーションを追加。
カテゴリ作成時のバリデーションと同様に、カテゴリ名の最大値を50文字に設定。

カテゴリIDが不正な場合、下記のエラーメッセージを返す。
```
不正なリクエストが行われました。
```

51文字以上入力された場合、下記のエラーメッセージを返す。
```
カテゴリ名は最大50文字です。カテゴリ名を短くしてください。
```

## 技術的変更点概要
`app/Models/Domain/Category/CategorySpecification.php`に、カテゴリIDのバリデーションを追加。
カテゴリIDの最大値は、符号無しBIGINTの最大値としている。