### PR TITLE
Qiitaのユーザ名を保存するテーブル定義を作成

### DIFF
--- a/app/Eloquents/QiitaUserName.php
+++ b/app/Eloquents/QiitaUserName.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class QiitaUserName extends Model
+{
+    /**
+     * モデルと関連しているテーブル
+     *
+     * @var string
+     */
+    protected $table = 'accounts_qiita_user_names';
+}

--- a/app/Infrastructure/Repositories/AccountRepository.php
+++ b/app/Infrastructure/Repositories/AccountRepository.php
@@ -9,16 +9,16 @@ use App\Eloquents\Account;
 use App\Eloquents\AccessToken;
 use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
-use App\Models\Domain\AccountEntity;
 use App\Models\Domain\QiitaAccountValue;
-use App\Models\Domain\LoginSessionEntity;
-use App\Models\Domain\AccountEntityBuilder;
+use App\Models\Domain\Account\AccountEntity;
+use App\Models\Domain\Account\AccountEntityBuilder;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 
 /**
  * Class AccountRepository
  * @package App\Infrastructure\Repositories
  */
-class AccountRepository implements \App\Models\Domain\AccountRepository
+class AccountRepository implements \App\Models\Domain\Account\AccountRepository
 {
     /**
      * アカウントを作成する

--- a/app/Infrastructure/Repositories/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/CategoryRepository.php
@@ -7,7 +7,7 @@ namespace App\Infrastructure\Repositories;
 
 use App\Eloquents\Category;
 use App\Eloquents\CategoryName;
-use App\Models\Domain\AccountEntity;
+use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryEntities;
 use App\Models\Domain\Category\CategoryNameValue;

--- a/app/Infrastructure/Repositories/LoginSessionRepository.php
+++ b/app/Infrastructure/Repositories/LoginSessionRepository.php
@@ -6,14 +6,14 @@
 namespace App\Infrastructure\Repositories;
 
 use App\Eloquents\LoginSession;
-use App\Models\Domain\LoginSessionEntity;
-use App\Models\Domain\LoginSessionEntityBuilder;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
+use App\Models\Domain\LoginSession\LoginSessionEntityBuilder;
 
 /**
  * Class LoginSessionRepository
  * @package App\Infrastructure\Repositories
  */
-class LoginSessionRepository implements \App\Models\Domain\LoginSessionRepository
+class LoginSessionRepository implements \App\Models\Domain\LoginSession\LoginSessionRepository
 {
     /**
      * LoginSessionEntityを取得する

--- a/app/Models/Domain/Account/AccountEntity.php
+++ b/app/Models/Domain/Account/AccountEntity.php
@@ -3,10 +3,12 @@
  * AccountEntity
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\Account;
 
+use App\Models\Domain\QiitaAccountValue;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryRepository;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 
 /**
  * Class AccountEntity
@@ -92,12 +94,12 @@ class AccountEntity
      * 退会する
      *
      * @param AccountRepository $accountRepository
-     * @param LoginSessionRepository $loginSessionRepository
+     * @param LoginSessionEntity $loginSessionRepository
      * @param CategoryRepository $categoryRepository
      */
     public function cancel(
         AccountRepository $accountRepository,
-        LoginSessionRepository $loginSessionRepository,
+        LoginSessionEntity $loginSessionRepository,
         CategoryRepository $categoryRepository
     ) {
         $categoryRepository->destroyAll($this->getAccountId());

--- a/app/Models/Domain/Account/AccountEntityBuilder.php
+++ b/app/Models/Domain/Account/AccountEntityBuilder.php
@@ -3,7 +3,7 @@
  * AccountEntityBuilder
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\Account;
 
 /**
  * Class AccountEntityBuilder

--- a/app/Models/Domain/Account/AccountRepository.php
+++ b/app/Models/Domain/Account/AccountRepository.php
@@ -3,7 +3,10 @@
  * AccountRepository
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\Account;
+
+use App\Models\Domain\QiitaAccountValue;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 
 /**
  * Interface AccountRepository

--- a/app/Models/Domain/Account/AccountSpecification.php
+++ b/app/Models/Domain/Account/AccountSpecification.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * LoginSessionSpecification
+ * AccountSpecification
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\Account;
 
 /**
- * Class LoginSessionSpecification
+ * Class AccountSpecification
  * @package App\Models\Domain
  */
-class LoginSessionSpecification
+class AccountSpecification
 {
     /**
-     * ログイン可能か確認する
+     * アカウント作成可能か確認する
      *
      * @param array $requestArray
      * @return array

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -5,7 +5,7 @@
 
 namespace App\Models\Domain\Category;
 
-use App\Models\Domain\AccountEntity;
+use App\Models\Domain\Account\AccountEntity;
 
 /**
  * Interface CategoryRepository

--- a/app/Models/Domain/LoginSession/LoginSessionEntity.php
+++ b/app/Models/Domain/LoginSession/LoginSessionEntity.php
@@ -3,7 +3,10 @@
  * LoginSessionEntity
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\LoginSession;
+
+use App\Models\Domain\Account\AccountEntity;
+use App\Models\Domain\Account\AccountRepository;
 
 /**
  * Class LoginSessionEntity

--- a/app/Models/Domain/LoginSession/LoginSessionEntityBuilder.php
+++ b/app/Models/Domain/LoginSession/LoginSessionEntityBuilder.php
@@ -3,7 +3,7 @@
  * LoginSessionEntityBuilder
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\LoginSession;
 
 /**
  * Class LoginSessionEntityBuilder

--- a/app/Models/Domain/LoginSession/LoginSessionRepository.php
+++ b/app/Models/Domain/LoginSession/LoginSessionRepository.php
@@ -3,7 +3,7 @@
  * LoginSessionRepository
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\LoginSession;
 
 /**
  * Interface LoginSessionRepository

--- a/app/Models/Domain/LoginSession/LoginSessionSpecification.php
+++ b/app/Models/Domain/LoginSession/LoginSessionSpecification.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * AccountSpecification
+ * LoginSessionSpecification
  */
 
-namespace App\Models\Domain;
+namespace App\Models\Domain\LoginSession;
 
 /**
- * Class AccountSpecification
+ * Class LoginSessionSpecification
  * @package App\Models\Domain
  */
-class AccountSpecification
+class LoginSessionSpecification
 {
     /**
-     * アカウント作成可能か確認する
+     * ログイン可能か確認する
      *
      * @param array $requestArray
      * @return array

--- a/app/Models/Domain/QiitaAccountValue.php
+++ b/app/Models/Domain/QiitaAccountValue.php
@@ -5,6 +5,8 @@
 
 namespace App\Models\Domain;
 
+use App\Models\Domain\Account\AccountEntity;
+use App\Models\Domain\Account\AccountRepository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,9 +7,9 @@ use App\Services\CategoryScenario;
 use App\Services\LoginSessionScenario;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
-use App\Models\Domain\AccountRepository;
-use App\Models\Domain\LoginSessionRepository;
+use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Category\CategoryRepository;
+use App\Models\Domain\LoginSession\LoginSessionRepository;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -6,19 +6,19 @@
 namespace App\Services;
 
 use Ramsey\Uuid\Uuid;
-use App\Models\Domain\AccountEntity;
-use App\Models\Domain\AccountRepository;
 use App\Models\Domain\QiitaAccountValue;
-use App\Models\Domain\LoginSessionEntity;
-use App\Models\Domain\AccountSpecification;
-use App\Models\Domain\LoginSessionRepository;
+use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\QiitaAccountValueBuilder;
-use App\Models\Domain\LoginSessionEntityBuilder;
+use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Category\CategoryRepository;
+use App\Models\Domain\Account\AccountSpecification;
 use App\Models\Domain\Exceptions\ValidationException;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\Exceptions\AccountCreatedException;
+use App\Models\Domain\LoginSession\LoginSessionRepository;
+use App\Models\Domain\LoginSession\LoginSessionEntityBuilder;
 use App\Models\Domain\Exceptions\LoginSessionExpiredException;
 
 /**
@@ -77,6 +77,7 @@ class AccountScenario
     public function create(array $requestArray): array
     {
         try {
+            // TODO バリデーションを追加
             $errors = AccountSpecification::canCreate($requestArray);
             if ($errors) {
                 throw new ValidationException(QiitaAccountValue::createAccountValidationErrorMessage(), $errors);
@@ -93,6 +94,8 @@ class AccountScenario
 
             \DB::beginTransaction();
 
+            // TODO AccountEntityを修正
+            // TODO テーブル定義を修正を修正
             $accountEntity = $this->accountRepository->create($qiitaAccountValue);
 
             $sessionId = Uuid::uuid4();

--- a/app/Services/Authentication.php
+++ b/app/Services/Authentication.php
@@ -5,12 +5,12 @@
 
 namespace App\Services;
 
-use App\Models\Domain\AccountEntity;
+use App\Models\Domain\Account\AccountEntity;
 
-use App\Models\Domain\AccountRepository;
-use App\Models\Domain\LoginSessionEntity;
-use App\Models\Domain\LoginSessionRepository;
+use App\Models\Domain\Account\AccountRepository;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 use App\Models\Domain\Exceptions\UnauthorizedException;
+use App\Models\Domain\LoginSession\LoginSessionRepository;
 use App\Models\Domain\Exceptions\LoginSessionExpiredException;
 
 /**

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -5,17 +5,17 @@
 
 namespace App\Services;
 
-use App\Models\Domain\AccountRepository;
-use App\Models\Domain\LoginSessionEntity;
-use App\Models\Domain\LoginSessionRepository;
 use App\Models\Domain\Category\CategoryEntity;
+use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Category\CategoryNameValue;
 use App\Models\Domain\Category\CategoryRepository;
 use App\Models\Domain\Category\CategoryEntityBuilder;
 use App\Models\Domain\Category\CategorySpecification;
 use App\Models\Domain\Exceptions\ValidationException;
+use App\Models\Domain\LoginSession\LoginSessionEntity;
 use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Models\Domain\LoginSession\LoginSessionRepository;
 use App\Models\Domain\Exceptions\CategoryNotFoundException;
 use App\Models\Domain\exceptions\LoginSessionExpiredException;
 

--- a/app/Services/LoginSessionScenario.php
+++ b/app/Services/LoginSessionScenario.php
@@ -6,14 +6,14 @@
 namespace App\Services;
 
 use Ramsey\Uuid\Uuid;
-use App\Models\Domain\AccountEntity;
-use App\Models\Domain\AccountRepository;
 use App\Models\Domain\QiitaAccountValue;
+use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\QiitaAccountValueBuilder;
-use App\Models\Domain\LoginSessionEntityBuilder;
-use App\Models\Domain\LoginSessionSpecification;
+use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Exceptions\ValidationException;
 use App\Models\Domain\Exceptions\AccountNotFoundException;
+use App\Models\Domain\LoginSession\LoginSessionEntityBuilder;
+use App\Models\Domain\LoginSession\LoginSessionSpecification;
 
 /**
  * Class LoginSessionScenario

--- a/database/migrations/2018_12_10_004032_create_accounts_qiita_user_names_table.php
+++ b/database/migrations/2018_12_10_004032_create_accounts_qiita_user_names_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAccountsQiitaUserNamesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('accounts_qiita_user_names', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('account_id');
+            $table->string('user_name');
+            $table->unsignedInteger('lock_version')->default(0);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            $table->unique('account_id', 'uq_accounts_qiita_user_names_01');
+            $table->unique('user_name', 'uq_accounts_qiita_user_names_02');
+            $table->foreign('account_id', 'fk_accounts_qiita_user_names_01')->references('id')->on('accounts');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('accounts_qiita_user_names');
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/57

# Doneの定義
- アカウント作成時にQiitaアカウントIDも保存できていること

# 変更点概要

## 仕様的変更点概要
Qiitaのユーザ名を保存するためのテーブルを作成。

## 技術的変更点概要
Qiitaのユーザ名を保存するため、マイグレーションファイルを作成。
上記のEloquentモデルを作成。
- `database/migrations/2018_12_10_004032_create_accounts_qiita_user_names_table.php`
- `app/Eloquents/QiitaUserName.php`

また、今回のIssueとは直接関係ないがリファクタリングとして
`app/Models/Domain`配下に`Account`ディレクトリと`LoginSession`ディレクトリを作成。