### PR TITLE
ユーザ名のバリデーションを追加

### DIFF
--- a/app/Models/Domain/Account/AccountSpecification.php
+++ b/app/Models/Domain/Account/AccountSpecification.php
@@ -12,7 +12,7 @@ namespace App\Models\Domain\Account;
 class AccountSpecification
 {
     /**
-     * アカウント作成可能か確認する
+     * QiitaAccountValueが作成可能か確認する
      *
      * @param array $requestArray
      * @return array

--- a/app/Models/Domain/Account/AccountSpecification.php
+++ b/app/Models/Domain/Account/AccountSpecification.php
@@ -17,11 +17,12 @@ class AccountSpecification
      * @param array $requestArray
      * @return array
      */
-    public static function canCreate(array $requestArray): array
+    public static function canCreateQiitaAccountValue(array $requestArray): array
     {
         $validator = \Validator::make($requestArray, [
-            'accessToken' => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
-            'permanentId' => 'required|integer|min:1|max:4294967294',
+            'accessToken'    => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
+            'permanentId'    => 'required|integer|min:1|max:4294967294',
+            'qiitaAccountId' => 'required|min:1|max:191',
         ]);
 
         if ($validator->fails()) {

--- a/app/Models/Domain/LoginSession/LoginSessionSpecification.php
+++ b/app/Models/Domain/LoginSession/LoginSessionSpecification.php
@@ -12,16 +12,17 @@ namespace App\Models\Domain\LoginSession;
 class LoginSessionSpecification
 {
     /**
-     * ログイン可能か確認する
+     * QiitaAccountValueが作成可能か確認する
      *
      * @param array $requestArray
      * @return array
      */
-    public static function canCreate(array $requestArray): array
+    public static function canCreateQiitaAccountValue(array $requestArray): array
     {
         $validator = \Validator::make($requestArray, [
-            'accessToken' => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
-            'permanentId' => 'required|integer|min:1|max:4294967294',
+            'accessToken'    => 'required|regex:/^[a-z0-9]+$/|min:40|max:64',
+            'permanentId'    => 'required|integer|min:1|max:4294967294',
+            'qiitaAccountId' => 'required|min:1|max:191',
         ]);
 
         if ($validator->fails()) {

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -77,8 +77,7 @@ class AccountScenario
     public function create(array $requestArray): array
     {
         try {
-            // TODO ユーザ名のバリデーションを追加
-            $errors = AccountSpecification::canCreate($requestArray);
+            $errors = AccountSpecification::canCreateQiitaAccountValue($requestArray);
             if ($errors) {
                 throw new ValidationException(QiitaAccountValue::createAccountValidationErrorMessage(), $errors);
             }

--- a/app/Services/LoginSessionScenario.php
+++ b/app/Services/LoginSessionScenario.php
@@ -48,7 +48,7 @@ class LoginSessionScenario
     public function create(array $requestArray): array
     {
         try {
-            $errors = LoginSessionSpecification::canCreate($requestArray);
+            $errors = LoginSessionSpecification::canCreateQiitaAccountValue($requestArray);
             if ($errors) {
                 throw new ValidationException(QiitaAccountValue::createLoginSessionValidationErrorMessage(), $errors);
             }

--- a/tests/Feature/AccountCreateTest.php
+++ b/tests/Feature/AccountCreateTest.php
@@ -222,5 +222,47 @@ class AccountCreateTest extends AbstractTestCase
         ];
     }
 
-    // TODO ユーザ名のバリデーションテスト
+    /**
+     * 異常系のテスト
+     * アカウント作成時のユーザ名のバリデーション
+     *
+     * @param $userName
+     * @dataProvider userNameProvider
+     */
+    public function testErrorCreateUserNameValidation($userName)
+    {
+        $accessToken = 'ea5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a5';
+        $permanentId = '123456';
+
+        $jsonResponse = $this->postJson(
+            '/api/accounts',
+            [
+                'permanentId'    => $permanentId,
+                'qiitaAccountId' => $userName,
+                'accessToken'    => $accessToken
+            ]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、アカウント登録を行なってください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * ユーザ名のデータプロバイダ
+     *
+     * @return array
+     */
+    public function userNameProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'emptyArray'         => [[]],
+            'tooLongLength'      => [str_repeat('a', 192)]
+        ];
+    }
 }

--- a/tests/Feature/LoginSessionTest.php
+++ b/tests/Feature/LoginSessionTest.php
@@ -208,5 +208,47 @@ class LoginSessionTest extends AbstractTestCase
         ];
     }
 
-    // TODO ユーザ名のバリデーションテスト
+    /**
+     * 異常系のテスト
+     * ログイン作成時のユーザ名のバリデーション
+     *
+     * @param $userName
+     * @dataProvider userNameProvider
+     */
+    public function testErrorLoginUserNameValidation($userName)
+    {
+        $accessToken = 'ea5d0a593b2655e9568f144fb1826342292f5c6b7d406fda00577b8d1530d8a5';
+        $permanentId = '123456';
+
+        $jsonResponse = $this->postJson(
+            '/api/login-sessions',
+            [
+                'permanentId'    => $permanentId,
+                'qiitaAccountId' => $userName,
+                'accessToken'    => $accessToken
+            ]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * ユーザ名のデータプロバイダ
+     *
+     * @return array
+     */
+    public function userNameProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'emptyArray'         => [[]],
+            'tooLongLength'      => [str_repeat('a', 192)]
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/57

# Doneの定義
- アカウント作成APIにユーザ名のバリデーションが追加されていること
- ログインAPIにユーザ名のバリデーションが追加されていること

# 変更点概要

## 仕様的変更点概要
 アカウント作成APIとログインAPIにユーザ名のバリデーションを追加。

## 技術的変更点概要
ユーザ名のバリデーションを追加し、テストケースも追加。
ユーザ名の最大値は、[ここ](https://github.com/nekochans/qiita-stocker-backend/blob/master/app/Providers/AppServiceProvider.php#L23)で設定した`191`としている。