### PR TITLE
ユーザ名の同期処理を作成する

### DIFF
--- a/app/Infrastructure/Repositories/AccountRepository.php
+++ b/app/Infrastructure/Repositories/AccountRepository.php
@@ -148,6 +148,19 @@ class AccountRepository implements \App\Models\Domain\Account\AccountRepository
     }
 
     /**
+     * ユーザ名を更新する
+     *
+     * @param AccountEntity $accountEntity
+     * @param QiitaAccountValue $qiitaAccountValue
+     */
+    public function updateQiitaUserName(AccountEntity $accountEntity, QiitaAccountValue $qiitaAccountValue)
+    {
+        $qiitaUserName = QiitaUserName::where('account_id', $accountEntity->getAccountId())->first();
+        $qiitaUserName->user_name = $qiitaAccountValue->getUserName();
+        $qiitaUserName->save();
+    }
+
+    /**
      * アカウントを取得する
      *
      * @param string $accountId

--- a/app/Models/Domain/Account/AccountEntity.php
+++ b/app/Models/Domain/Account/AccountEntity.php
@@ -108,7 +108,7 @@ class AccountEntity
     }
 
     /**
-     * ユーザ名が確認されているか確認する
+     * ユーザ名が更新されているか確認する
      *
      * @param QiitaAccountValue $qiitaAccountValue
      * @return bool

--- a/app/Models/Domain/Account/AccountEntity.php
+++ b/app/Models/Domain/Account/AccountEntity.php
@@ -108,6 +108,8 @@ class AccountEntity
     }
 
     /**
+     * ユーザ名が確認されているか確認する
+     *
      * @param QiitaAccountValue $qiitaAccountValue
      * @return bool
      */

--- a/app/Models/Domain/Account/AccountEntity.php
+++ b/app/Models/Domain/Account/AccountEntity.php
@@ -108,6 +108,37 @@ class AccountEntity
     }
 
     /**
+     * @param QiitaAccountValue $qiitaAccountValue
+     * @return bool
+     */
+    public function isChangedQiitaUserName(QiitaAccountValue $qiitaAccountValue): bool
+    {
+        if ($this->userName !== $qiitaAccountValue->getUserName()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * ユーザ名を更新する
+     *
+     * @param AccountRepository $accountRepository
+     * @param QiitaAccountValue $qiitaAccountValue
+     * @return AccountEntity
+     */
+    public function updateQiitaUserName(AccountRepository $accountRepository, QiitaAccountValue $qiitaAccountValue): AccountEntity
+    {
+        $accountRepository->updateQiitaUserName($this, $qiitaAccountValue);
+
+        $accountEntityBuilder = new AccountEntityBuilder();
+        $accountEntityBuilder->setAccountId($this->accountId);
+        $accountEntityBuilder->setUserName($qiitaAccountValue->getUserName());
+        $accountEntityBuilder->setPermanentId($this->permanentId);
+        $accountEntityBuilder->setAccessToken($this->accessToken);
+        return $accountEntityBuilder->build();
+    }
+
+    /**
      * 退会する
      *
      * @param AccountRepository $accountRepository

--- a/app/Models/Domain/Account/AccountRepository.php
+++ b/app/Models/Domain/Account/AccountRepository.php
@@ -47,6 +47,14 @@ interface AccountRepository
     public function updateAccessToken(AccountEntity $accountEntity, QiitaAccountValue $qiitaAccountValue);
 
     /**
+     * ユーザ名を更新する
+     *
+     * @param AccountEntity $accountEntity
+     * @param QiitaAccountValue $qiitaAccountValue
+     */
+    public function updateQiitaUserName(AccountEntity $accountEntity, QiitaAccountValue $qiitaAccountValue);
+
+    /**
      * アカウントを取得する
      *
      * @param string $accountId

--- a/app/Services/LoginSessionScenario.php
+++ b/app/Services/LoginSessionScenario.php
@@ -68,6 +68,11 @@ class LoginSessionScenario
             \DB::beginTransaction();
 
             $accountEntity = $accountEntity->updateAccessToken($this->accountRepository, $qiitaAccountValue);
+
+            if ($accountEntity->isChangedQiitaUserName($qiitaAccountValue)) {
+                $accountEntity = $accountEntity->updateQiitaUserName($this->accountRepository, $qiitaAccountValue);
+            }
+
             $sessionId = Uuid::uuid4();
 
             // TODO 有効期限を適切な期限に修正


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/90

# Doneの定義
- ログイン時にユーザ名が同期されること

# 変更点概要

## 仕様的変更点概要
ログインAPIにユーザ名を更新する処理を追加。

## 技術的変更点概要
ユーザ名が変更されているか確認し、変更されていた場合のみユーザ名を更新する処理を追加。
テストついては、ユーザ名が更新されている場合と更新されていない場合の両方のテストケースを作成した。