### PR TITLE
ストック同期APIのインターフェースを定義する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * StockController
+ */
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Class StockController
+ * @package App\Http\Controllers
+ */
+class StockController extends Controller
+{
+    /**
+     * ストックを同期する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function synchronize(Request $request): JsonResponse
+    {
+        return response()->json()->setStatusCode(200);
+    }
+}

--- a/app/Http/Middleware/Cors.php
+++ b/app/Http/Middleware/Cors.php
@@ -17,7 +17,7 @@ class Cors
     {
         return $next($request)
             ->header('Access-Control-Allow-Origin', env('CORS_ORIGIN'))
-            ->header('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+            ->header('Access-Control-Allow-Methods', 'GET, POST, PATCH, PUT, DELETE, OPTIONS')
             ->header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,4 +38,10 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
     Route::post('categories', 'CategoryController@create');
 
     Route::patch('categories/{id}', 'CategoryController@update');
+
+    Route::options('stocks', function () {
+        return response()->json();
+    });
+
+    Route::put('stocks', 'StockController@synchronize');
 });

--- a/tests/Feature/StockSynchronize.php
+++ b/tests/Feature/StockSynchronize.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * StockSynchronize
+ */
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class StockSynchronize
+ * @package Tests\Feature
+ */
+class StockSynchronize extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系のテスト
+     * ストックの同期ができること
+     */
+    public function testSuccess()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        $jsonResponse = $this->put(
+            '/api/stocks',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $jsonResponse->assertStatus(200);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/55

# Doneの定義
- ストック同期APIのインターフェースが定義されていること

# 変更点概要

## 仕様的変更点概要
ストック同期APIのIFを定義
`PUT api/stocks`

リクエスト
```
curl -X PUT -kv \
-H "Authorization: Bearer e28b5056-6b1b-4f91-a2b5-fdea13f327cb" \
http://127.0.0.1/api/stocks
```
HTTPレスポンスHeader
```
HTTP/1.1 200 OK
Content-Type: application/json
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```
HTTPレスポンスBody : なし

## 技術的変更点概要
ルーティングを設定
テストコードを追加