### PR TITLE
データベースを定義する

### DIFF
--- a/app/Eloquents/Stock.php
+++ b/app/Eloquents/Stock.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Stock extends Model
+{
+    /**
+     * モデルと関連しているテーブル
+     *
+     * @var string
+     */
+    protected $table = 'stocks';
+}

--- a/app/Eloquents/StockTag.php
+++ b/app/Eloquents/StockTag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StockTag extends Model
+{
+    /**
+     * モデルと関連しているテーブル
+     *
+     * @var string
+     */
+    protected $table = 'stocks_tags';
+}

--- a/database/migrations/2018_12_11_170954_create_stocks_table.php
+++ b/database/migrations/2018_12_11_170954_create_stocks_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateStocksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('stocks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('account_id');
+            $table->string('article_id');
+            $table->text('title');
+            $table->string('user_Id');
+            $table->text('profile_image_url');
+            $table->dateTime('article_created_at');
+            $table->unsignedInteger('lock_version')->default(0);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            $table->foreign('account_id', 'fk_stocks_01')->references('id')->on('accounts');
+            $table->index('account_id', 'idx_stocks_01');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('stocks');
+    }
+}

--- a/database/migrations/2018_12_11_170954_create_stocks_table.php
+++ b/database/migrations/2018_12_11_170954_create_stocks_table.php
@@ -18,7 +18,7 @@ class CreateStocksTable extends Migration
             $table->unsignedInteger('account_id');
             $table->string('article_id');
             $table->text('title');
-            $table->string('user_Id');
+            $table->string('user_id');
             $table->text('profile_image_url');
             $table->dateTime('article_created_at');
             $table->unsignedInteger('lock_version')->default(0);

--- a/database/migrations/2018_12_11_173912_create_stocks_tags_table.php
+++ b/database/migrations/2018_12_11_173912_create_stocks_tags_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateStocksTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('stocks_tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('stock_id');
+            $table->text('name');
+            $table->unsignedInteger('lock_version')->default(0);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            $table->foreign('stock_id', 'fk_stocks_tags_01')->references('id')->on('stocks');
+            $table->index('stock_id', 'idx_stocks_tags_01');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('stocks_tags');
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/55

# 関連URL
[Qiita APIドキュメント](https://qiita.com/api/v2/docs#get-apiv2usersuser_idstocks)

# Doneの定義
- データベースが定義されていること

# 変更点概要

## 技術的変更点概要
マイグレーションファイルとEloquentモデルを作成。
テーブルは下記を追加。
- stocks
- stocks_tags

### テーブル定義について補足
- 記事のタイトルは255文字まで入力可能となっていたため、text型を指定
 (string型の最大値を191に設定しているため、string型ではなくtext型を指定)
- タグ名については、text型の最大値である`65535`文字以上も登録可能であったが、データ自体が存在しないと思われるためtext型を指定

### カテゴリとストックのリレーションについて
カテゴリとストックのリレーションは、中間テーブルを作成する予定。
ストックテーブルにカテゴリIDを外部キーとするカラムを追加し、カテゴリとストックのリレーションを作成する方法も検討したが以下の理由により中間テーブルを作成することにした。

- ストックがカテゴリに分類されていない場合、ストックテーブルのカテゴリIDが`null`になってしまう
    -> それを回避するために、カテゴリテーブルに`未分類`のカテゴリを作成する方法もあるが、未分類カテゴリがシステム的に作成されたのか、ユーザによって作成されたのかを判断する必要が出てくるため処理が複雑になる
- 現在の仕様ではカテゴリとストックが1対多であるが、もし多対多になった場合には中間テーブルが必要になる

# レビュアーに重点的にチェックして欲しい点
カテゴリとのリレーションにおける考慮が不足していないか。

# 補足情報
## めも
QiitaAPIのレスポンスの`group`は、QiitaTeamにおいてグループが作成されており、かつ、ストックされた記事の公開範囲にそのグループが指定されていた場合のみ値が設定される。
今回は、QiitaTeamにおいて使用されることは検討していないため、考慮不要。