### PR TITLE
ストックの永続化処理を作成する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -21,7 +21,6 @@ class StockController extends Controller
      */
     private $stockScenario;
 
-
     /**
      * StockController constructor.
      * @param StockScenario $stockScenario

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -19,7 +19,13 @@ use App\Models\Domain\Category\CategoryEntityBuilder;
  */
 class CategoryRepository implements \App\Models\Domain\Category\CategoryRepository
 {
-    public function create(AccountEntity $accountEntity, CategoryNameValue $categoryNameValue): CategoryEntity
+    /**
+     * カテゴリを作成する
+     *
+     * @param AccountEntity $accountEntity
+     * @param CategoryNameValue $categoryNameValue
+     * @return CategoryEntity
+     */    public function create(AccountEntity $accountEntity, CategoryNameValue $categoryNameValue): CategoryEntity
     {
         $categoryId = $this->saveCategories($accountEntity->getAccountId());
         $this->saveCategoriesNames($categoryId, $categoryNameValue);

--- a/app/Infrastructure/Repositories/Eloquent/StockRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/StockRepository.php
@@ -5,6 +5,9 @@
 
 namespace App\Infrastructure\Repositories\Eloquent;
 
+use App\Eloquents\Stock;
+use App\Eloquents\StockTag;
+use App\Models\Domain\Stock\StockValue;
 use App\Models\Domain\Stock\StockValues;
 
 /**
@@ -16,11 +19,54 @@ class StockRepository implements \App\Models\Domain\Stock\StockRepository
     /**
      * ストックを保存する
      *
+     * @param string $accountId
      * @param StockValues $stockEntities
-     * @return mixed|void
+     * @return mixed
      */
-    public function save(StockValues $stockEntities)
+    public function save(string $accountId, StockValues $stockEntities)
     {
-        // ストックをテーブルに保存する
+        $stockValueList = $stockEntities->getStockEntities();
+        foreach ($stockValueList as $stockValue) {
+            $stockId = $this->saveStocks($accountId, $stockValue);
+            $this->saveStocksTags($stockId, $stockValue->getTags());
+        }
+    }
+
+    /**
+     * stocks テーブルにデータを保存する
+     *
+     * @param string $accountId
+     * @param StockValue $stockValue
+     * @return int
+     */
+    private function saveStocks(string $accountId, StockValue $stockValue): int
+    {
+        $stock = new Stock();
+        $stock->article_id = $stockValue->getArticleId();
+        $stock->title = $stockValue->getTitle();
+        $stock->user_id = $stockValue->getUserId();
+        $stock->profile_image_url = $stockValue->getProfileImageUrl();
+        $stock->article_created_at = $stockValue->getArticleCreatedAt();
+        $stock->account_id = $accountId;
+        $stock->save();
+        $stockId = $stock->getAttribute('id');
+
+        return $stockId;
+    }
+
+    /**
+     * stocks_tags テーブルにデータを保存する
+     *
+     * @param int $stockId
+     * @param array $tags
+     */
+    private function saveStocksTags(int $stockId, array $tags)
+    {
+        foreach ($tags as $tag) {
+            $stockTag = new StockTag();
+            $stockTag->stock_id = $stockId;
+            $stockTag->name = $tag;
+            $stockTag->save();
+        }
     }
 }

--- a/app/Models/Domain/Stock/StockRepository.php
+++ b/app/Models/Domain/Stock/StockRepository.php
@@ -14,8 +14,9 @@ interface StockRepository
     /**
      * ストックを保存する
      *
+     * @param string $accountId
      * @param StockValues $stockEntities
      * @return mixed
      */
-    public function save(StockValues $stockEntities);
+    public function save(string $accountId, StockValues $stockEntities);
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use App\Services\StockScenario;
 use App\Services\AccountScenario;
 use App\Services\CategoryScenario;
+use Tests\Feature\TestClientHandler;
 use App\Services\LoginSessionScenario;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -104,6 +105,14 @@ class AppServiceProvider extends ServiceProvider
                 );
             }
         );
+
+        $this->app->bind(Client::class, function () {
+            if (config('app.env') == 'testing') {
+                $handler = TestClientHandler::create();
+                return new Client(['handler' => $handler]);
+            }
+            return new Client();
+        });
 
         $this->app->bind(
             Repository::class,

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -85,7 +85,7 @@ class StockScenario
 
             \DB::beginTransaction();
 
-            $this->stockRepository->save($stockValues);
+            $this->stockRepository->save($accountEntity->getAccountId(), $stockValues);
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/database/factories/StockFactory.php
+++ b/database/factories/StockFactory.php
@@ -1,0 +1,20 @@
+<?php
+use Faker\Generator as Faker;
+
+$factory->define(\App\Eloquents\Stock::class, function (Faker $faker) {
+    return [
+        'account_id'               => '1',
+        'article_id'               => $faker->unique()->regexify('[a-z0-9]{20}'),
+        'title'                    => $faker->sentence,
+        'user_id'                  => $faker->userName,
+        'profile_image_url'        => $faker->url,
+        'article_created_at'       => $faker->dateTimeThisDecade,
+    ];
+});
+
+$factory->define(\App\Eloquents\StockTag::class, function (Faker $faker) {
+    return [
+        'stock_id'                => '1',
+        'name'                    => $faker->word,
+    ];
+});

--- a/tests/Feature/AbstractTestCase.php
+++ b/tests/Feature/AbstractTestCase.php
@@ -6,8 +6,10 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use App\Eloquents\Stock;
 use App\Eloquents\Account;
 use App\Eloquents\Category;
+use App\Eloquents\StockTag;
 use Tests\CreatesApplication;
 use App\Eloquents\AccessToken;
 use App\Eloquents\CategoryName;
@@ -35,6 +37,8 @@ abstract class AbstractTestCase extends TestCase
         QiitaUserName::truncate();
         Category::truncate();
         CategoryName::truncate();
+        Stock::truncate();
+        StockTag::truncate();
         \DB::statement('SET FOREIGN_KEY_CHECKS=1');
     }
 

--- a/tests/Feature/StockSynchronizeTest.json
+++ b/tests/Feature/StockSynchronizeTest.json
@@ -1,0 +1,90 @@
+[
+    {
+        "rendered_body": "<h1>Example</h1>",
+        "body": "# Example",
+        "coediting": false,
+        "comments_count": 0,
+        "created_at": "2018-12-12T09:00:43+09:00",
+        "group": null,
+        "id": "4bd431809afb1bb99e4f",
+        "likes_count": 50,
+        "private": false,
+        "reactions_count": 0,
+        "tags": [
+            {
+                "name": "Ruby",
+                "versions": []
+            },
+            {
+                "name": "PHP",
+                "versions": []
+            }
+        ],
+        "title": "Example title",
+        "updated_at": "2018-12-12T09:00:43+09:00",
+        "url": "https://qiita.com/yaotti/items/4bd431809afb1bb99e4f",
+        "user": {
+            "description": "Hello, world.",
+            "facebook_id": "yaotti",
+            "followees_count": 100,
+            "followers_count": 200,
+            "github_login_name": "yaotti",
+            "id": "yaotti",
+            "items_count": 300,
+            "linkedin_id": "yaotti",
+            "location": "Tokyo, Japan",
+            "name": "neko",
+            "organization": "test Inc",
+            "permanent_id": 1,
+            "profile_image_url": "https://si0.twimg.com/profile_images/2309761038/1ijg13pfs0dg84sk2y0h_normal.jpeg",
+            "team_only": false,
+            "twitter_screen_name": "",
+            "website_url": ""
+        },
+        "page_views_count": null
+    },
+    {
+        "rendered_body": "<h1>Example2</h1>",
+        "body": "# Example2",
+        "coediting": false,
+        "comments_count": 0,
+        "created_at": "2018-12-31T11:00:43+09:00",
+        "group": null,
+        "id": "4bd431809afb1bb99e4a",
+        "likes_count": 50,
+        "private": false,
+        "reactions_count": 0,
+        "tags": [
+            {
+                "name": "JavaScript",
+                "versions": []
+            },
+            {
+                "name": "Typescript",
+                "versions": []
+            }
+        ],
+        "title": "Example title2",
+        "updated_at": "2018-12-31T11:00:43+09:00",
+        "url": "https://qiita.com/user2/items/4bd431809afb1bb99e4a",
+        "user": {
+            "description": "Hello, world.",
+            "facebook_id": "user",
+            "followees_count": 100,
+            "followers_count": 200,
+            "github_login_name": "user",
+            "id": "test-user",
+            "items_count": 300,
+            "linkedin_id": "user2",
+            "location": "Tokyo, Japan",
+            "name": "user2",
+            "organization": "test Inc",
+            "permanent_id": 1,
+            "profile_image_url": "https://avatars3.githubusercontent.com/u/32682645?v=4",
+            "team_only": false,
+            "twitter_screen_name": "",
+            "website_url": ""
+        },
+        "page_views_count": null
+    }
+]

--- a/tests/Feature/TestClientHandler.php
+++ b/tests/Feature/TestClientHandler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * TestClientHandler
+ */
+
+namespace Tests\Feature;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+
+class TestClientHandler
+{
+    /**
+     * テスト用のHandlerを生成する
+     *
+     * @return HandlerStack
+     */
+    public static function create(): HandlerStack
+    {
+        $body = file_get_contents(dirname(__FILE__) . '/StockSynchronizeTest.json');
+        $mock = new MockHandler([
+            new Response(200, [], $body)
+        ]);
+        return HandlerStack::create($mock);
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/55

# Doneの定義
- APIから取得したストックが永続化されていること

# 変更点概要

## 仕様的変更点概要
ストックをDBに保存する処理を作成。
このPRでは差分の更新は行わない。

## 技術的変更点概要
Eloquent ORMを利用したDBへの保存処理を作成。
`AppServiceProvider`にて`Guzzle Client`の`handler`をテスト用のモックに変更する処理を追加している。