### PR TITLE
レスポンスの日付のフォーマットを修正

### DIFF
--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -138,7 +138,7 @@ class StockScenario
                 'title'                    => $stockEntity->getStockValue()->getTitle(),
                 'user_id'                  => $stockEntity->getStockValue()->getUserId(),
                 'profile_image_url'        => $stockEntity->getStockValue()->getProfileImageUrl(),
-                'article_created_at'       => $stockEntity->getStockValue()->getArticleCreatedAt(),
+                'article_created_at'       => $stockEntity->getStockValue()->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
                 'tags'                     => $stockEntity->getStockValue()->getTags(),
             ];
 

--- a/tests/Feature/StockIndexTest.php
+++ b/tests/Feature/StockIndexTest.php
@@ -137,7 +137,7 @@ class StockIndexTest extends AbstractTestCase
                 'user_id'                   => 'user-id-' . $i,
                 'profile_image_url'         => 'http://test.com/test-image-updated.jpag'. $i,
                 'article_created_at_object' => $articleCreatedAtObject,
-                'article_created_at'        => $articleCreatedAtArray,
+                'article_created_at'        => $articleCreatedAtArray['date'],
                 'tags'                      => ['tag'. $i, 'tag'. $secondTag]
             ];
             array_push($stocks, $stock);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/99

# Doneの定義
- `article_created_at`の形式が `Y-m-d H:i:s.u` となっていること

# 変更点概要

## 技術的変更点概要
`article_created_at`の形式が以下の通りになっていたので、 `Y-m-d H:i:s.u`に修正。

修正前
```
"article_created_at":{
  "date":"2014-03-28 16:36:07.000000",
  "timezone_type":3,
  "timezone":"Asia\/Tokyo"
}
```

修正後
```
"article_created_at":"2014-03-28 16:36:07.000000"
```