### PR TITLE
ログアウトAPIのIFを定義する

### DIFF
--- a/app/Http/Controllers/LoginSessionController.php
+++ b/app/Http/Controllers/LoginSessionController.php
@@ -46,4 +46,15 @@ class LoginSessionController extends Controller
 
         return response()->json($sessionId)->setStatusCode(201);
     }
+
+    /**
+     * ログインセッションを削除する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        return response()->json()->setStatusCode(204);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,8 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
 
     Route::post('login-sessions', 'LoginSessionController@create');
 
+    Route::delete('login-sessions', 'LoginSessionController@destroy');
+
     Route::options('categories/{id?}', function () {
         return response()->json();
     });

--- a/tests/Feature/AccountDestroyTest.php
+++ b/tests/Feature/AccountDestroyTest.php
@@ -63,7 +63,6 @@ class AccountDestroyTest extends AbstractTestCase
             '/api/accounts',
             [],
             ['Authorization' => 'Bearer '.$loginSession]
-
         );
 
         $jsonResponse->assertStatus(204);

--- a/tests/Feature/LoginSessionCreateTest.php
+++ b/tests/Feature/LoginSessionCreateTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * LoginSessionTest
+ * LoginSessionCreateTest
  */
 
 namespace Tests\Feature;
@@ -13,10 +13,10 @@ use App\Eloquents\QiitaUserName;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
- * Class LoginSessionTest
+ * Class LoginSessionCreateTest
  * @package Tests\Feature
  */
-class LoginSessionTest extends AbstractTestCase
+class LoginSessionCreateTest extends AbstractTestCase
 {
     use RefreshDatabase;
 

--- a/tests/Feature/LoginSessionDestroy.php
+++ b/tests/Feature/LoginSessionDestroy.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * LoginSessionDestroy
+ */
+
+namespace Tests\Feature;
+
+use App\Eloquents\Account;
+use App\Eloquents\AccessToken;
+use App\Eloquents\LoginSession;
+use App\Eloquents\QiitaAccount;
+use App\Eloquents\QiitaUserName;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class LoginSessionDestroy
+ * @package Tests\Feature
+ */
+class LoginSessionDestroy extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $accounts = factory(Account::class)->create();
+        $accounts->each(function ($account) {
+            factory(QiitaAccount::class)->create(['account_id' => $account->id]);
+            factory(QiitaUserName::class)->create(['account_id' => $account->id]);
+            factory(AccessToken::class)->create(['account_id' => $account->id]);
+            factory(LoginSession::class)->create(['account_id' => $account->id]);
+        });
+    }
+
+    /**
+     * 正常系のテスト
+     * ログアウトできること
+     */
+    public function testSuccess()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        $jsonResponse = $this->delete(
+            '/api/login-sessions',
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+}

--- a/tests/Feature/LoginSessionDestroyTest.php
+++ b/tests/Feature/LoginSessionDestroyTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * LoginSessionDestroy
+ * LoginSessionDestroyTest
  */
 
 namespace Tests\Feature;
@@ -13,10 +13,10 @@ use App\Eloquents\QiitaUserName;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
- * Class LoginSessionDestroy
+ * Class LoginSessionDestroyTest
  * @package Tests\Feature
  */
-class LoginSessionDestroy extends AbstractTestCase
+class LoginSessionDestroyTest extends AbstractTestCase
 {
     use RefreshDatabase;
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/59

# Doneの定義
- ログアウトAPIのIFが定義されていること

# 変更点概要

## 仕様的変更点概要
ログアウトAPIのIFを定義
`DELETE api/login-sessions`

リクエスト
```
curl -X DELETE -kv \
-H "Authorization: Bearer 18fc017f-b83b-4f74-8bb3-08807fe056fb"  \
http://127.0.0.1/api/login-sessions
```
HTTPレスポンスHeader
```
HTTP/1.1 204 No Content
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```
HTTPレスポンスBody : なし

## 技術的変更点概要
ルーティングを設定
テストコードを追加