### PR TITLE
ストック取得APIにバリデーションを追加する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -57,6 +57,7 @@ class StockController extends Controller
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
      */
     public function index(Request $request): JsonResponse
     {

--- a/app/Infrastructure/Repositories/Eloquent/AccountRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/AccountRepository.php
@@ -7,13 +7,11 @@ namespace App\Infrastructure\Repositories\Eloquent;
 
 use App\Eloquents\Account;
 use App\Eloquents\AccessToken;
-use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
 use App\Eloquents\QiitaUserName;
 use App\Models\Domain\QiitaAccountValue;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Account\AccountEntityBuilder;
-use App\Models\Domain\LoginSession\LoginSessionEntity;
 
 /**
  * Class AccountRepository

--- a/app/Models/Domain/Account/AccountRepository.php
+++ b/app/Models/Domain/Account/AccountRepository.php
@@ -6,7 +6,6 @@
 namespace App\Models\Domain\Account;
 
 use App\Models\Domain\QiitaAccountValue;
-use App\Models\Domain\LoginSession\LoginSessionEntity;
 
 /**
  * Interface AccountRepository

--- a/app/Models/Domain/Stock/StockEntities.php
+++ b/app/Models/Domain/Stock/StockEntities.php
@@ -123,4 +123,14 @@ class StockEntities
             $stockRepository->saveStocksTags($stockEntity->getId(), $insertTagList);
         }
     }
+
+    /**
+     * ストック取得時のバリデーションエラーの場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function searchStocksErrorMessage(): string
+    {
+        return '不正なリクエストが行われました。';
+    }
 }

--- a/app/Models/Domain/Stock/StockSpecification.php
+++ b/app/Models/Domain/Stock/StockSpecification.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * StockSpecification
+ */
+
+namespace App\Models\Domain\Stock;
+
+/**
+ * Class StockSpecification
+ * @package App\Models\Domain\Stock
+ */
+class StockSpecification
+{
+    /**
+     * ストックが検索可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canSearchStocks(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'page'       => 'required|integer|min:1|max:100',
+            'perPage'    => 'required|integer|min:1|max:100',
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
+}

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -6,11 +6,14 @@
 namespace App\Services;
 
 use App\Models\Domain\QiitaApiRepository;
+use App\Models\Domain\Stock\StockEntities;
 use GuzzleHttp\Exception\RequestException;
 use App\Models\Domain\Stock\LinkHeaderValue;
 use App\Models\Domain\Stock\StockRepository;
 use App\Models\Domain\Stock\LinkHeaderService;
+use App\Models\Domain\Stock\StockSpecification;
 use App\Models\Domain\Account\AccountRepository;
+use App\Models\Domain\Exceptions\ValidationException;
 use App\Models\Domain\LoginSession\LoginSessionEntity;
 use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -109,12 +112,17 @@ class StockScenario
      * @param array $params
      * @return array
      * @throws UnauthorizedException
+     * @throws ValidationException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      */
     public function index(array $params): array
     {
         try {
-            // TODO page と per_page のバリデーション
+            $errors = StockSpecification::canSearchStocks($params);
+            if ($errors) {
+                throw new ValidationException(StockEntities::searchStocksErrorMessage(), $errors);
+            }
+
             $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
 
             $limit = $params['perPage'];

--- a/tests/Feature/StockIndexTest.php
+++ b/tests/Feature/StockIndexTest.php
@@ -211,4 +211,108 @@ class StockIndexTest extends AbstractTestCase
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
+
+    /**
+     * 異常系のテスト
+     * ストック取得時のクエリパラメータ page のバリデーション
+     *
+     * @param $page
+     * @dataProvider pageProvider
+     */
+    public function testErrorPageValidation($page)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        $uri = sprintf(
+            '/api/stocks?page=%s&per_page=%d',
+            $page,
+            2
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * page のデータプロバイダ
+     *
+     * @return array
+     */
+    public function pageProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'string'             => ['a'],
+            'symbol'             => ['1/'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [101],
+        ];
+    }
+
+    /**
+     * 異常系のテスト
+     * ストック取得時のクエリパラメータ perPage のバリデーション
+     *
+     * @param $perPage
+     * @dataProvider perPageProvider
+     */
+    public function testErrorPerPageValidation($perPage)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        $uri = sprintf(
+            '/api/stocks?page=%d&per_page=%s',
+            1,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * perPage のデータプロバイダ
+     *
+     * @return array
+     */
+    public function perPageProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'string'             => ['a'],
+            'symbol'             => ['1;'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [101],
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/113

# Doneの定義
- バリデーションが追加されていること

# 変更点概要

## 仕様的変更点概要
クエリパラメータ のバリデーションを下記の通り設定。
- page : 1から100まで
- per_page : 1から100まで

```
HTTP/1.1 422 Unprocessable Entity
{
  "code":422,
  "message":"不正なリクエストが行われました。",
  "errors":{"page":["The page field is required."]}
}
```
`errors`は、Laravelのバリデーションメッセージ

## 技術的変更点概要
仕様クラス`StockSpecification`を作成し、ストック取得時のバリデーションを追加。