### PR TITLE
APIのIFとテーブルを定義する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -100,4 +100,27 @@ class CategoryController extends Controller
 
         return response()->json($category)->setStatusCode(200);
     }
+
+
+    /**
+     * 指定されたカテゴリとストックのリレーションを作成する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function categorize(Request $request): JsonResponse
+    {
+        $requestArray = $request->json()->all();
+
+        $sessionId = $request->bearerToken();
+        $params = [
+            'sessionId' => $sessionId
+        ];
+
+        $params = array_merge($params, $requestArray);
+
+        // TODO シナリオクラス作成
+
+        return response()->json()->setStatusCode(201);
+    }
 }

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -30,25 +30,26 @@ class StockController extends Controller
         $this->stockScenario = $stockScenario;
     }
 
-    /**
-     * ストックを同期する
-     *
-     * @param Request $request
-     * @return JsonResponse
-     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
-     * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
-     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
-     */
-    public function synchronize(Request $request): JsonResponse
-    {
-        $sessionId = $request->bearerToken();
-        $params = [
-            'sessionId' => $sessionId
-        ];
-
-        $this->stockScenario->synchronize($params);
-        return response()->json()->setStatusCode(200);
-    }
+    // TODO 削除する
+//    /**
+//     * ストックを同期する
+//     *
+//     * @param Request $request
+//     * @return JsonResponse
+//     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+//     * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
+//     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+//     */
+//    public function synchronize(Request $request): JsonResponse
+//    {
+//        $sessionId = $request->bearerToken();
+//        $params = [
+//            'sessionId' => $sessionId
+//        ];
+//
+//        $this->stockScenario->synchronize($params);
+//        return response()->json()->setStatusCode(200);
+//    }
 
     /**
      * ストック一覧を取得する

--- a/database/migrations/2018_12_25_114434_create_categories_stocks_table.php
+++ b/database/migrations/2018_12_25_114434_create_categories_stocks_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCategoriesStocksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories_stocks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('category_id');
+            $table->string('article_id');
+            $table->unsignedInteger('lock_version')->default(0);
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            $table->foreign('category_id', 'fk_categories_stocks_01')->references('id')->on('categories');
+            $table->index('category_id', 'idx_categories_stocks_01');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories_stocks');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,11 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
         return response()->json();
     });
 
-    Route::put('stocks', 'StockController@synchronize');
-
     Route::get('stocks', 'StockController@index');
+
+    Route::options('categories/stocks', function () {
+        return response()->json();
+    });
+
+    Route::post('categories/stocks', 'CategoryController@categorize');
 });

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -28,7 +28,7 @@ class CategoryCategorizeTest extends AbstractTestCase
         $jsonResponse = $this->postJson(
             '/api/categories/stocks',
             [
-                'categoryId' => $categoryId,
+                'id' => $categoryId,
                 'articleIds' => ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333']
             ],
             ['Authorization' => 'Bearer ' . $loginSession]

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CategoryCategorizeTest
+ */
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class CategoryCategorizeTest
+ * @package Tests\Feature
+ */
+class CategoryCategorizeTest extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系のテスト
+     * カテゴリとストックのリレーションが作成されること
+     */
+    public function testSuccessCreate()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+
+        $categoryId = 1;
+
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'categoryId' => $categoryId,
+                'articleIds' => ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333']
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $jsonResponse->assertStatus(201);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/100

# Doneの定義
- APIのIFが定義されていること
- マイグレーションが作成されDBスキーマが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴライズAPIのIFを定義
`POST api/categories/stocks`

リクエスト
```
curl -X POST -kv \
-H "Content-Type: application/json" \
-H "Authorization: Bearer 18fc017f-b83b-4f74-8bb3-08807fe056fa" \
-d \
'
{
  "id": "1",
  "articleIds": ["d210ddc2cb1bfeea9331","d210ddc2cb1bfeea9332","d210ddc2cb1bfeea9333"]
}
' \
http://127.0.0.1/api/categories/stocks
```

HTTPレスポンスHeader
```
HTTP/1.1 201 Created
Content-Type: application/json
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```

HTTPレスポンスBody : なし

## 技術的変更点概要
ルーティングを設定。
以下のテーブルを作成。
- categories_stocks
