### PR TITLE
カテゴリとストックのリレーションテーブルへの登録処理

### DIFF
--- a/app/Eloquents/CategoryStock.php
+++ b/app/Eloquents/CategoryStock.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * CategoryStock
+ */
+
+namespace App\Eloquents;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CategoryStock extends Model
+{
+    /**
+     * モデルと関連しているテーブル
+     *
+     * @var string
+     */
+    protected $table = 'categories_stocks';
+}

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -123,8 +123,6 @@ class CategoryController extends Controller
         $params = array_merge($params, $requestArray);
         $this->categoryScenario->categorize($params);
 
-        // TODO シナリオクラス作成
-
         return response()->json()->setStatusCode(201);
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -109,6 +109,7 @@ class CategoryController extends Controller
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
      * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      */
     public function categorize(Request $request): JsonResponse

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -107,6 +107,9 @@ class CategoryController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      */
     public function categorize(Request $request): JsonResponse
     {
@@ -118,6 +121,7 @@ class CategoryController extends Controller
         ];
 
         $params = array_merge($params, $requestArray);
+        $this->categoryScenario->categorize($params);
 
         // TODO シナリオクラス作成
 

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -7,6 +7,7 @@ namespace App\Infrastructure\Repositories\Eloquent;
 
 use App\Eloquents\Category;
 use App\Eloquents\CategoryName;
+use App\Eloquents\CategoryStock;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryEntities;
@@ -139,7 +140,6 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
         return $this->buildCategoryEntity($params);
     }
 
-
     /**
      * カテゴリ名を更新する
      *
@@ -152,5 +152,21 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
         $categoryName->name = $categoryEntity->getCategoryNameValue()->getName();
 
         $categoryName->save();
+    }
+
+    /**
+     * カテゴリとストックのリレーションを作成する
+     *
+     * @param CategoryEntity $categoryEntity
+     * @param array $articleIdList
+     */
+    public function createCategoriesStocks(CategoryEntity $categoryEntity, array $articleIdList)
+    {
+        foreach ($articleIdList as $articleId) {
+            $categoryStock = new CategoryStock();
+            $categoryStock->category_id = $categoryEntity->getId();
+            $categoryStock->article_id = $articleId;
+            $categoryStock->save();
+        }
     }
 }

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -70,4 +70,14 @@ class CategoryEntity
     {
         return '不正なリクエストが行われました。';
     }
+
+    /**
+     * カテゴリが作成されていなかった場合に使用するメッセージ
+     *
+     * @return string
+     */
+    public static function createCategoriesStocksValidationErrorMessage(): string
+    {
+        return '不正なリクエストが行われました。';
+    }
 }

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -52,4 +52,12 @@ interface CategoryRepository
      * @param CategoryEntity $categoryEntity
      */
     public function updateName(CategoryEntity $categoryEntity);
+
+    /**
+     * カテゴリとストックのリレーションを作成する
+     *
+     * @param CategoryEntity $categoryEntity
+     * @param array $articleIdList
+     */
+    public function createCategoriesStocks(CategoryEntity $categoryEntity, array $articleIdList);
 }

--- a/app/Models/Domain/Category/CategorySpecification.php
+++ b/app/Models/Domain/Category/CategorySpecification.php
@@ -46,4 +46,22 @@ class CategorySpecification
         }
         return [];
     }
+
+    /**
+     * CategoryEntity が作成可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canCreateCategoriesStocks(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'articleIds.*'   => 'required|regex:/^[0-9a-f]+$/|min:20|max:20'
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
 }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -217,7 +217,12 @@ class CategoryScenario
             if ($errors) {
                 throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
             }
-            // TODO articleIdsのバリデーション
+
+            $errors = CategorySpecification::canCreateCategoriesStocks($params);
+            if ($errors) {
+                throw new ValidationException(CategoryEntity::createCategoriesStocksValidationErrorMessage(), $errors);
+            }
+
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
             \DB::beginTransaction();

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -200,6 +200,7 @@ class CategoryScenario
      * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
+     * @throws ValidationException
      */
     public function categorize(array $params)
     {
@@ -212,7 +213,10 @@ class CategoryScenario
         }
 
         try {
-            // TODO idのバリデーション
+            $errors = CategorySpecification::canSetCategoryEntityId($params);
+            if ($errors) {
+                throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
+            }
             // TODO articleIdsのバリデーション
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -192,4 +192,41 @@ class CategoryScenario
 
         return $category;
     }
+
+    /**
+     * カテゴリとストックのリレーションを作成する
+     *
+     * @param array $params
+     * @throws CategoryNotFoundException
+     * @throws LoginSessionExpiredException
+     * @throws UnauthorizedException
+     */
+    public function categorize(array $params)
+    {
+        try {
+            $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
+        } catch (ModelNotFoundException $e) {
+            throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
+        } catch (\PDOException $e) {
+            throw $e;
+        }
+
+        try {
+            // TODO idのバリデーション
+            // TODO articleIdsのバリデーション
+            $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
+
+            \DB::beginTransaction();
+
+            // TODO カテゴリIDとarticleIDの組み合わせが存在しなかった場合、リレーションを作成する
+            $this->categoryRepository->createCategoriesStocks($categoryEntity, $params['articleIds']);
+
+            \DB::commit();
+        } catch (ModelNotFoundException $e) {
+            throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
+        } catch (\PDOException $e) {
+            \DB::rollBack();
+            throw $e;
+        }
+    }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -14,3 +14,10 @@ $factory->define(\App\Eloquents\CategoryName::class, function (Faker $faker) {
         'name'              => $faker->word,
     ];
 });
+
+$factory->define(\App\Eloquents\CategoryStock::class, function (Faker $faker) {
+    return [
+        'category_id'       => '1',
+        'article_id'        => $faker->unique()->regexify('[a-z0-9]{20}'),
+    ];
+});

--- a/tests/Feature/AbstractTestCase.php
+++ b/tests/Feature/AbstractTestCase.php
@@ -16,9 +16,9 @@ use GuzzleHttp\Psr7\Response;
 use Tests\CreatesApplication;
 use App\Eloquents\AccessToken;
 use App\Eloquents\CategoryName;
-
 use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
+use App\Eloquents\CategoryStock;
 use App\Eloquents\QiitaUserName;
 use GuzzleHttp\Handler\MockHandler;
 
@@ -42,6 +42,7 @@ abstract class AbstractTestCase extends TestCase
         QiitaUserName::truncate();
         Category::truncate();
         CategoryName::truncate();
+        CategoryStock::truncate();
         Stock::truncate();
         StockTag::truncate();
         \DB::statement('SET FOREIGN_KEY_CHECKS=1');

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -5,6 +5,15 @@
 
 namespace Tests\Feature;
 
+use App\Eloquents\Account;
+use App\Eloquents\Category;
+use App\Eloquents\AccessToken;
+use App\Eloquents\CategoryName;
+use App\Eloquents\LoginSession;
+use App\Eloquents\QiitaAccount;
+use App\Eloquents\CategoryStock;
+use App\Eloquents\QiitaUserName;
+
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
@@ -15,27 +24,181 @@ class CategoryCategorizeTest extends AbstractTestCase
 {
     use RefreshDatabase;
 
+    public function setUp()
+    {
+        parent::setUp();
+        $accounts = factory(Account::class)->create();
+        $accounts->each(function ($account) {
+            factory(QiitaAccount::class)->create(['account_id' => $account->id]);
+            factory(QiitaUserName::class)->create(['account_id' => $account->id]);
+            factory(AccessToken::class)->create(['account_id' => $account->id]);
+            factory(LoginSession::class)->create(['account_id' => $account->id]);
+            $categories = factory(Category::class)->create(['account_id' => $account->id]);
+            $categories->each(function ($category) {
+                factory(CategoryName::class)->create(['category_id' => $category->id]);
+                factory(CategoryStock::class)->create(['category_id' => $category->id]);
+            });
+        });
+    }
+
     /**
      * 正常系のテスト
      * カテゴリとストックのリレーションが作成されること
      */
-    public function testSuccessCreate()
+    public function testSuccess()
     {
         $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
 
         $categoryId = 1;
-
+        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
         $jsonResponse = $this->postJson(
             '/api/categories/stocks',
             [
-                'id' => $categoryId,
-                'articleIds' => ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333']
+                'id'         => $categoryId,
+                'articleIds' => $articleIds
             ],
             ['Authorization' => 'Bearer ' . $loginSession]
         );
 
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $jsonResponse->assertStatus(201);
+        $jsonResponse->assertHeader('X-Request-Id');
+
+        // DBのテーブルに期待した形でデータが入っているか確認する
+        $idSequence = 2;
+        for ($i = 0; $i < count($articleIds); $i++) {
+            $this->assertDatabaseHas('categories_stocks', [
+                'id'                => $idSequence,
+                'category_id'       => $categoryId,
+                'article_id'        => $articleIds[$i],
+                'lock_version'      => 0,
+            ]);
+            $idSequence += 1;
+        }
+    }
+
+    /**
+     * 異常系のテスト
+     * カテゴリが見つからない場合エラーとなること
+     */
+    public function testErrorCategoryIdNotFound()
+    {
+        $otherAccountId = 2;
+        $otherCategoryId = 2;
+        $otherCategoryName = 'accountIDが2のカテゴリ';
+
+        factory(Account::class)->create();
+        factory(QiitaAccount::class)->create(['qiita_account_id' => 2, 'account_id' => $otherAccountId]);
+        factory(QiitaUserName::class)->create(['account_id' => $otherAccountId]);
+        factory(AccessToken::class)->create(['account_id' => $otherAccountId]);
+        factory(LoginSession::class)->create(['account_id' => $otherAccountId]);
+        factory(Category::class)->create(['account_id' => $otherAccountId]);
+        factory(CategoryName::class)->create(['category_id' => $otherCategoryId, 'name' => $otherCategoryName]);
+
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => $otherCategoryId,
+                'articleIds' => $articleIds
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 404;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * Authorizationが存在しない場合エラーとなること
+     */
+    public function testErrorLoginSessionNull()
+    {
+        $categoryId = 1;
+        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => $categoryId,
+                'articleIds' => $articleIds
+            ]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが不正の場合エラーとなること
+     */
+    public function testErrorLoginSessionNotFound()
+    {
+        $loginSession = 'notFound-2bae-4028-b53d-0f128479e650';
+        $categoryId = 1;
+        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
+
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => $categoryId,
+                'articleIds' => $articleIds
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが有効期限切れの場合エラーとなること
+     */
+    public function testErrorLoginSessionIsExpired()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $categoryId = 1;
+        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
+        factory(LoginSession::class)->create([
+            'id'         => $loginSession,
+            'account_id' => 1,
+            'expired_on' => '2018-10-01 00:00:00'
+        ]);
+
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => $categoryId,
+                'articleIds' => $articleIds
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/100

# Doneの定義
- カテゴリとストックのリレーションのデータが登録されていること

# 変更点概要

## 仕様的変更点概要
カテゴリとストックのリレーションのデータをDBに保存する処理を追加。

## 技術的変更点概要
`CategoryScenario`に以下の処理を追加
- セッションIDによる認証処理
- カテゴリIDがアカウントに紐付くカテゴリであるかの判定処理
- カテゴリ`Id`と`ArticleIds`のバリデーション

なお、ArticleIdは[QiitaAPI](https://qiita.com/api/v2/docs#%E6%8A%95%E7%A8%BF)に下記の通り記載があったため、これに相当するバリデーションを行なっている。
```
- id
 記事の一意なID
 Example: "4bd431809afb1bb99e4f"
 Type: string
 Pattern: /^[0-9a-f]{20}$/
```

# 補足
下記のケースについては、別のPRにて対応予定
カテゴリIDとArticleIDのリレーションが既にDBに存在する -> DBにレコードを追加しない
ArticleIDが他のカテゴリに紐づいている場合 -> 既存のリレーションを削除して、新規にレーションを作成