### PR TITLE
DBへの登録時の差分確認処理を追加する

### DIFF
--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -186,4 +186,37 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
 
         return $stockArticleIds->toArray();
     }
+
+    /**
+     * 指定したカテゴリ以外にカテゴライズされているストックのArticleID一覧を取得する
+     *
+     * @param AccountEntity $accountEntity
+     * @param CategoryEntity $categoryEntity
+     * @param array $articleIdList
+     * @return array
+     */
+    public function searchCategoriesStocksByArticleId(AccountEntity $accountEntity, CategoryEntity $categoryEntity, array $articleIdList): array
+    {
+        $categories = Category::select('categories_stocks.id')
+            ->where('categories.account_id', $accountEntity->getAccountId())
+            ->where('categories.id', '<>', $categoryEntity->getId())
+            ->join('categories_stocks', function ($join) use ($articleIdList) {
+                $join->on('categories.id', '=', 'categories_stocks.category_id')
+                    ->whereIn('categories_stocks.article_id', $articleIdList);
+            })
+            ->get();
+
+        $stockArticleIds = $categories->pluck('id');
+        return $stockArticleIds->toArray();
+    }
+
+    /**
+     * カテゴリとストックのリレーションを削除する
+     *
+     * @param array $categoryStockRelationList
+     */
+    public function destroyCategoriesStocks(array $categoryStockRelationList)
+    {
+        CategoryStock::destroy($categoryStockRelationList);
+    }
 }

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -169,4 +169,21 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
             $categoryStock->save();
         }
     }
+
+    /**
+     * カテゴリとストックのリレーションを取得する
+     *
+     * @param CategoryEntity $categoryEntity
+     * @return array
+     */
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): array
+    {
+        $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())->get();
+
+        $stockArticleIds = $categoryStocks->map(function (CategoryStock $categoryStock): string {
+            return $categoryStock->article_id;
+        });
+
+        return $stockArticleIds->toArray();
+    }
 }

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -52,6 +52,17 @@ class CategoryEntity
     }
 
     /**
+     * カテゴリが持つストックのリストを取得する
+     *
+     * @param CategoryRepository $categoryRepository
+     * @return array
+     */
+    public function searchHadStockList(CategoryRepository $categoryRepository): array
+    {
+        return $categoryRepository->searchCategoriesStocksByCategoryId($this);
+    }
+
+    /**
      * カテゴリIDのバリデーションエラー時に利用するメッセージ
      *
      * @return string

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -5,6 +5,8 @@
 
 namespace App\Models\Domain\Category;
 
+use App\Models\Domain\Account\AccountEntity;
+
 /**
  * Class CategoryEntity
  * @package App\Models\Domain
@@ -52,14 +54,62 @@ class CategoryEntity
     }
 
     /**
+     * ストックをカテゴライズする
+     *
+     * @param CategoryRepository $categoryRepository
+     * @param AccountEntity $accountEntity
+     * @param array $articleIds
+     */
+    public function categorize(CategoryRepository $categoryRepository, AccountEntity $accountEntity, array $articleIds)
+    {
+        $this->destroyRelation($categoryRepository, $accountEntity, $articleIds);
+        $this->createRelation($categoryRepository, $articleIds);
+    }
+
+    /**
      * カテゴリが持つストックのリストを取得する
      *
      * @param CategoryRepository $categoryRepository
      * @return array
      */
-    public function searchHadStockList(CategoryRepository $categoryRepository): array
+    private function searchHadStockList(CategoryRepository $categoryRepository): array
     {
         return $categoryRepository->searchCategoriesStocksByCategoryId($this);
+    }
+
+    /**
+     * 既存のストックとその他のカテゴリとのリレーションを削除する
+     *
+     * @param CategoryRepository $categoryRepository
+     * @param AccountEntity $accountEntity
+     * @param array $articleIds
+     */
+    private function destroyRelation(CategoryRepository $categoryRepository, AccountEntity $accountEntity, array $articleIds)
+    {
+        $categorizedArticleIds = $categoryRepository->searchCategoriesStocksByArticleId($accountEntity, $this, $articleIds);
+        $categoryRepository->destroyCategoriesStocks($categorizedArticleIds);
+    }
+
+    /**
+     * カテゴリとストックのリレーションを作成する
+     *
+     * @param CategoryRepository $categoryRepository
+     * @param array $articleIds
+     */
+    private function createRelation(CategoryRepository $categoryRepository, array $articleIds)
+    {
+        $stockArticleIdList = $this->searchHadStockList($categoryRepository);
+
+        $saveArticleIds = [];
+        foreach ($articleIds as $articleId) {
+            if (!in_array($articleId, $stockArticleIdList)) {
+                array_push($saveArticleIds, $articleId);
+            }
+        }
+
+        if ($saveArticleIds) {
+            $categoryRepository->createCategoriesStocks($this, $saveArticleIds);
+        }
     }
 
     /**

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -60,4 +60,12 @@ interface CategoryRepository
      * @param array $articleIdList
      */
     public function createCategoriesStocks(CategoryEntity $categoryEntity, array $articleIdList);
+
+    /**
+     * カテゴリとストックのリレーションを取得する
+     *
+     * @param CategoryEntity $categoryEntity
+     * @return array
+     */
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): array;
 }

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -68,4 +68,21 @@ interface CategoryRepository
      * @return array
      */
     public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): array;
+
+    /**
+     * 指定したカテゴリ以外にカテゴライズされているストックのArticleID一覧を取得する
+     *
+     * @param AccountEntity $accountEntity
+     * @param CategoryEntity $categoryEntity
+     * @param array $articleIdList
+     * @return array
+     */
+    public function searchCategoriesStocksByArticleId(AccountEntity $accountEntity, CategoryEntity $categoryEntity, array $articleIdList): array;
+
+    /**
+     * カテゴリとストックのリレーションを削除する
+     *
+     * @param array $categoryStockRelationList
+     */
+    public function destroyCategoriesStocks(array $categoryStockRelationList);
 }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -225,10 +225,22 @@ class CategoryScenario
 
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
+            $stockArticleIdList = $categoryEntity->searchHadStockList($this->categoryRepository);
+
             \DB::beginTransaction();
 
-            // TODO カテゴリIDとarticleIDの組み合わせが存在しなかった場合、リレーションを作成する
-            $this->categoryRepository->createCategoriesStocks($categoryEntity, $params['articleIds']);
+            // TODO ArticleIDが他のカテゴリに紐づいている場合の処理を追加
+
+            $saveArticleIds = [];
+            foreach ($params['articleIds'] as $articleId) {
+                if (!in_array($articleId, $stockArticleIdList)) {
+                    array_push($saveArticleIds, $articleId);
+                }
+            }
+
+            if ($saveArticleIds) {
+                $this->categoryRepository->createCategoriesStocks($categoryEntity, $saveArticleIds);
+            }
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -218,6 +218,7 @@ class CategoryScenario
                 throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
             }
 
+            // TODO カテゴライズするストックの上限を設定する
             $errors = CategorySpecification::canCreateCategoriesStocks($params);
             if ($errors) {
                 throw new ValidationException(CategoryEntity::createCategoriesStocksValidationErrorMessage(), $errors);
@@ -225,11 +226,11 @@ class CategoryScenario
 
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
-            $stockArticleIdList = $categoryEntity->searchHadStockList($this->categoryRepository);
-
             \DB::beginTransaction();
+            $savedArticleIds = $this->categoryRepository->searchCategoriesStocksByArticleId($accountEntity, $categoryEntity, $params['articleIds']);
+            $this->categoryRepository->destroyCategoriesStocks($savedArticleIds);
 
-            // TODO ArticleIDが他のカテゴリに紐づいている場合の処理を追加
+            $stockArticleIdList = $categoryEntity->searchHadStockList($this->categoryRepository);
 
             $saveArticleIds = [];
             foreach ($params['articleIds'] as $articleId) {

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -227,21 +227,8 @@ class CategoryScenario
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
             \DB::beginTransaction();
-            $savedArticleIds = $this->categoryRepository->searchCategoriesStocksByArticleId($accountEntity, $categoryEntity, $params['articleIds']);
-            $this->categoryRepository->destroyCategoriesStocks($savedArticleIds);
 
-            $stockArticleIdList = $categoryEntity->searchHadStockList($this->categoryRepository);
-
-            $saveArticleIds = [];
-            foreach ($params['articleIds'] as $articleId) {
-                if (!in_array($articleId, $stockArticleIdList)) {
-                    array_push($saveArticleIds, $articleId);
-                }
-            }
-
-            if ($saveArticleIds) {
-                $this->categoryRepository->createCategoriesStocks($categoryEntity, $saveArticleIds);
-            }
+            $categoryEntity->categorize($this->categoryRepository, $accountEntity, $params['articleIds']);
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -49,10 +49,12 @@ class CategoryCategorizeTest extends AbstractTestCase
     {
         $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
         $accountId = 1;
-        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
-
         $categoryId = 1;
-        $articleIds = ['d210ddc2cb1bfeea9331','d210ddc2cb1bfeea9332','d210ddc2cb1bfeea9333'];
+        $savedArticleId = 'd210ddc2cb1bfeea9331';
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+        factory(CategoryStock::class)->create(['category_id' => $categoryId, 'article_id' => $savedArticleId]);
+
+        $articleIds = ['d210ddc2cb1bfeea9332',$savedArticleId,'d210ddc2cb1bfeea9333'];
         $jsonResponse = $this->postJson(
             '/api/categories/stocks',
             [
@@ -67,16 +69,24 @@ class CategoryCategorizeTest extends AbstractTestCase
         $jsonResponse->assertHeader('X-Request-Id');
 
         // DBのテーブルに期待した形でデータが入っているか確認する
-        $idSequence = 2;
-        for ($i = 0; $i < count($articleIds); $i++) {
-            $this->assertDatabaseHas('categories_stocks', [
-                'id'                => $idSequence,
-                'category_id'       => $categoryId,
-                'article_id'        => $articleIds[$i],
-                'lock_version'      => 0,
-            ]);
-            $idSequence += 1;
-        }
+        $this->assertDatabaseHas('categories_stocks', [
+            'id'                => 2,
+            'category_id'       => $categoryId,
+            'article_id'        => $savedArticleId,
+            'lock_version'      => 0,
+        ]);
+        $this->assertDatabaseHas('categories_stocks', [
+            'id'                => 3,
+            'category_id'       => $categoryId,
+            'article_id'        => $articleIds[0],
+            'lock_version'      => 0,
+        ]);
+        $this->assertDatabaseHas('categories_stocks', [
+            'id'                => 4,
+            'category_id'       => $categoryId,
+            'article_id'        => $articleIds[2],
+            'lock_version'      => 0,
+        ]);
     }
 
     /**


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/100

# Doneの定義
- カテゴリとストックのリレーションが重複してDBに登録されないこと
- ストックが既に他のカテゴリと紐づいている場合、既存のリレーションが削除されていること

# 変更点概要

## 仕様的変更点概要
カテゴライズ処理に以下の処理を追加
- カテゴリIDとArticleIDのリレーションが既にDBに存在する場合、DBにレコードを追加しない
- ArticleIDが他のカテゴリに紐づいている場合、 既存のリレーションを削除する

## 技術的変更点概要
`CategoryEntity`にカテゴライズ処理を作成。

# 補足情報
カテゴライズするストック(`ArticleId`)の上限を設定していなかったので、次のPRでバリデーションに追加する。
