### PR TITLE
1度にカテゴライズできるストック数の上限を追加

### DIFF
--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -107,8 +107,9 @@ class CategoryEntity
             }
         }
 
-        if ($saveArticleIds) {
-            $categoryRepository->createCategoriesStocks($this, $saveArticleIds);
+        $uniqueSaveArticleIds = array_unique($saveArticleIds);
+        if ($uniqueSaveArticleIds) {
+            $categoryRepository->createCategoriesStocks($this, $uniqueSaveArticleIds);
         }
     }
 

--- a/app/Models/Domain/Category/CategorySpecification.php
+++ b/app/Models/Domain/Category/CategorySpecification.php
@@ -56,7 +56,7 @@ class CategorySpecification
     public static function canCreateCategoriesStocks(array $requestArray): array
     {
         $validator = \Validator::make($requestArray, [
-            'articleIds'     => 'required',
+            'articleIds'     => 'required|array|max:20',
             'articleIds.*'   => 'required|regex:/^[0-9a-f]+$/|min:20|max:20'
         ]);
 

--- a/app/Models/Domain/Category/CategorySpecification.php
+++ b/app/Models/Domain/Category/CategorySpecification.php
@@ -56,6 +56,7 @@ class CategorySpecification
     public static function canCreateCategoriesStocks(array $requestArray): array
     {
         $validator = \Validator::make($requestArray, [
+            'articleIds'     => 'required',
             'articleIds.*'   => 'required|regex:/^[0-9a-f]+$/|min:20|max:20'
         ]);
 

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -218,7 +218,6 @@ class CategoryScenario
                 throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
             }
 
-            // TODO カテゴライズするストックの上限を設定する
             $errors = CategorySpecification::canCreateCategoriesStocks($params);
             if ($errors) {
                 throw new ValidationException(CategoryEntity::createCategoriesStocksValidationErrorMessage(), $errors);

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -330,9 +330,12 @@ class CategoryCategorizeTest extends AbstractTestCase
 
     /**
      * 異常系のテスト
-     * ArticleIDのリストが空だった場合エラーになること
+     * ArticleIdsのバリデーション
+     *
+     * @param $articleIds
+     * @dataProvider articleIdsProvider
      */
-    public function testErrorArticleIdsValidation()
+    public function testErrorArticleIdsValidation($articleIds)
     {
         $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
         $accountId = 1;
@@ -342,7 +345,7 @@ class CategoryCategorizeTest extends AbstractTestCase
             '/api/categories/stocks',
             [
                 'id'         => 1,
-                'articleIds' => []
+                'articleIds' => $articleIds
             ],
             ['Authorization' => 'Bearer ' . $loginSession]
         );
@@ -353,5 +356,20 @@ class CategoryCategorizeTest extends AbstractTestCase
         $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * ArticleIDのデータプロバイダ
+     *
+     * @return array
+     */
+    public function articleIdsProvider()
+    {
+        return [
+            'emptyArray'                   => [[]],
+            'emptyString'                  => [''],
+            'notArray'                     => ['a210ddc2cb1bfeea9331'],
+            'tooLongLengthArray'           => [array_fill(0, 21, 'a210ddc2cb1bfeea9332')]
+        ];
     }
 }

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -327,4 +327,31 @@ class CategoryCategorizeTest extends AbstractTestCase
             'f-z'                     => ['gz10ddc2cb1bfeea9331']
         ];
     }
+
+    /**
+     * 異常系のテスト
+     * ArticleIDのリストが空だった場合エラーになること
+     */
+    public function testErrorArticleIdsValidation()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => 1,
+                'articleIds' => []
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/100

# Doneの定義
- 1度にカテゴライズできるストック数の上限が20件に設定されていること

# 変更点概要

## 仕様的変更点概要
 1度にカテゴライズできるストック数の上限を20件に設定

## 技術的変更点概要
`CategorySpecification.php`のバリーションに、`articleIds`の最大値を設定。
以下についてもバリデーションの考慮が漏れていたので、合わせて修正している。
- `articleIds`が必須であること
- `articleIds`が配列

また、`articleIds`のIdが重複していた場合、カテゴリとストックのリレーションが重複して登録されてしまっていたため、重複したデータが登録されないように修正した。