### PR TITLE
退会APIにストック情報の削除処理を追加

### DIFF
--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -116,6 +116,7 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
 
         $categoryIdList = $categories->get()->pluck('id');
         CategoryName::whereIn('category_id', $categoryIdList)->delete();
+        CategoryStock::whereIn('category_id', $categoryIdList)->delete();
 
         $categories->delete();
     }

--- a/tests/Feature/AccountDestroyTest.php
+++ b/tests/Feature/AccountDestroyTest.php
@@ -11,6 +11,7 @@ use App\Eloquents\AccessToken;
 use App\Eloquents\CategoryName;
 use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
+use App\Eloquents\CategoryStock;
 use App\Eloquents\QiitaUserName;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -34,6 +35,7 @@ class AccountDestroyTest extends AbstractTestCase
             $categories = factory(Category::class, 2)->create(['account_id' => $account->id]);
             $categories->each(function ($category) {
                 factory(CategoryName::class)->create(['category_id' => $category->id]);
+                factory(CategoryStock::class)->create(['category_id' => $category->id]);
             });
         });
     }
@@ -58,6 +60,7 @@ class AccountDestroyTest extends AbstractTestCase
 
         factory(Category::class)->create(['account_id' => $accountId]);
         factory(CategoryName::class)->create(['category_id' => 3]);
+        factory(CategoryStock::class)->create(['category_id' => 3]);
 
         $jsonResponse = $this->delete(
             '/api/accounts',
@@ -119,6 +122,16 @@ class AccountDestroyTest extends AbstractTestCase
             'category_id'   => 2,
         ]);
         $this->assertDatabaseHas('categories_names', [
+            'category_id'   => 3,
+        ]);
+
+        $this->assertDatabaseMissing('categories_stocks', [
+            'category_id'   => 1,
+        ]);
+        $this->assertDatabaseMissing('categories_stocks', [
+            'category_id'   => 2,
+        ]);
+        $this->assertDatabaseHas('categories_stocks', [
             'category_id'   => 3,
         ]);
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/109

# Doneの定義
- 退会時に、カテゴリとストックのリレーションテーブルのデータが削除されていること

# 変更点概要

## 技術的変更点概要
CategoryIdからカテゴリとストックのリレーションテーブルのデータを削除する処理を追加し、退会処理が行えるように修正。