### PR TITLE
カテゴライズ済みのストックを取得するAPIのIFを定義する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -79,4 +79,46 @@ class StockController extends Controller
             ->header('Total-Count', $response['totalCount'])
             ->header('Link', $response['link']);
     }
+
+    /**
+     * カテゴライズされたストック一覧を取得する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function showCategorized(Request $request): JsonResponse
+    {
+        $stocks = [
+            [
+                'id'                       => '1',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル',
+                'user_id'                  => 'test-user',
+                'profile_image_url'        => 'http://test.com/test-image.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ],
+            [
+                'id'                       => '2',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル2',
+                'user_id'                  => 'test-user2',
+                'profile_image_url'        => 'http://test.com/test-image2.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ]
+        ];
+
+        $totalCount = 9;
+        $link = '<http://127.0.0.1/api/stocks/categories/1?page=4&per_page=2>; rel="next", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=5&per_page=2>; rel="last", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=1&per_page=2>; rel="first", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=2&per_page=2>; rel="prev"';
+
+        return response()
+            ->json($stocks)
+            ->setStatusCode(200)
+            ->header('Total-Count', $totalCount)
+            ->header('Link', $link);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,12 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
 
     Route::get('stocks', 'StockController@index');
 
+    Route::options('stocks/categories/{id?}', function () {
+        return response()->json();
+    });
+
+    Route::get('stocks/categories/{id}', 'StockController@showCategorized');
+
     Route::options('categories/stocks', function () {
         return response()->json();
     });

--- a/tests/Feature/StockShowCategorizedTest.php
+++ b/tests/Feature/StockShowCategorizedTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * StockShowCategorizedTest
+ */
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class StockShowCategorizedTest
+ * @package Tests\Feature
+ */
+class StockShowCategorizedTest extends AbstractTestCase
+{
+    use RefreshDatabase;
+    /**
+     * 正常系のテスト
+     * カテゴライズされたストック一覧ができること
+     */
+    public function testSuccess()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $page = 2;
+        $perPage = 2;
+
+        $uri = sprintf(
+            '/api/stocks/categories/1?page=%d&per_page=%d',
+            $page,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        $stocks = [
+            [
+                'id'                       => '1',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル',
+                'user_id'                  => 'test-user',
+                'profile_image_url'        => 'http://test.com/test-image.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ],
+            [
+                'id'                       => '2',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル2',
+                'user_id'                  => 'test-user2',
+                'profile_image_url'        => 'http://test.com/test-image2.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ]
+        ];
+
+        $totalCount = 9;
+        $link = '<http://127.0.0.1/api/stocks/categories/1?page=4&per_page=2>; rel="next", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=5&per_page=2>; rel="last", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=1&per_page=2>; rel="first", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=2&per_page=2>; rel="prev"';
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $jsonResponse->assertJson($stocks);
+        $jsonResponse->assertStatus(200);
+        $jsonResponse->assertHeader('X-Request-Id');
+        $jsonResponse->assertHeader('Link', $link);
+        $jsonResponse->assertHeader('Total-Count', $totalCount);
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/116

# Doneの定義
- APIのIFが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴライズ済みストックを取得APIのIFを定義。
`GET api/stocks/categories/{id}`
ページングについては、`Link`ヘッダで返している。

リクエスト
```
curl -X GET -kv \
-H "Authorization: Bearer e28b5056-6b1b-4f91-a2b5-fdea13f327cb" \
http://127.0.0.1/api/stocks/categories/1?page=1\&per_page=2
```
- page : 1から100まで
- per_page : 1から100まで

HTTPレスポンスHeader
```
HTTP/1.1 200 OK
Content-Type: application/json
Total-Count: 9
Link: <http://127.0.0.1/api/stocks/categories/1?page=4&per_page=2>; rel="next", 
         <http://127.0.0.1/api/stocks/categories/1?page=5&per_page=2>; rel="last", 
         <http://127.0.0.1/api/stocks/categories/1?page=1&per_page=2>; rel="first", 
         <http://127.0.0.1/api/stocks/categories/1?page=2&per_page=2>; rel="prev"
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```
HTTPレスポンスBody
```
[
    {
        "id": "1",
        "article_id": "1234567890abcdefghij",
        "title": "タイトル",
        "user_id": "test-user",
        "profile_image_url": "http://test.com/test-image.jpag",
        "article_created_at": "2018-12-01 00:00:00.000000",
        "tags": [
            "laravel5.6",
            "laravel",
            "php"
        ]
    },
    {
        "id": "2",
        "article_id": "1234567890abcdefghij",
        "title": "タイトル2",
        "user_id": "test-user2",
        "profile_image_url": "http://test.com/test-image2.jpag",
        "article_created_at": "2018-12-01 00:00:00.000000",
        "tags": [
            "laravel5.6",
            "laravel",
            "php"
        ]
    }
]
```

## 技術的変更点概要
カテゴライズ済みストックを取得APIのルーティングを追加。
APIのテストケースを作成。
レスポンスの`Id`は、カテゴライズとストックのリレーションテーブルのIDを指定。
カテゴライズされたストックをカテゴリから外す機能を追加した場合に、使用する予定。

## 補足
このIssueとは関係ないが、下記の機能を検討している。
カテゴライズされたストックは、Qiitaのストックとの同期を取らないため、Qiita上でストックを解除した場合も、カテゴライズされたままになってしまう。
この点を解消するために、カテゴライズされたストックをカテゴリから外す機能を追加する。

