### PR TITLE
ストック取得処理を作成する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -85,7 +85,9 @@ class StockController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+     * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      */
     public function showCategorized(Request $request): JsonResponse

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -85,40 +85,26 @@ class StockController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      */
     public function showCategorized(Request $request): JsonResponse
     {
-        $stocks = [
-            [
-                'id'                       => '1',
-                'article_id'               => '1234567890abcdefghij',
-                'title'                    => 'タイトル',
-                'user_id'                  => 'test-user',
-                'profile_image_url'        => 'http://test.com/test-image.jpag',
-                'article_created_at'       => '2018-12-01 00:00:00.000000',
-                'tags'                     => ['laravel5.6', 'laravel', 'php']
-            ],
-            [
-                'id'                       => '2',
-                'article_id'               => '1234567890abcdefghij',
-                'title'                    => 'タイトル2',
-                'user_id'                  => 'test-user2',
-                'profile_image_url'        => 'http://test.com/test-image2.jpag',
-                'article_created_at'       => '2018-12-01 00:00:00.000000',
-                'tags'                     => ['laravel5.6', 'laravel', 'php']
-            ]
+        $sessionId = $request->bearerToken();
+        $params = [
+            'sessionId'    => $sessionId,
+            'id'           => $request->id,
+            'page'         => $request->query('page'),
+            'perPage'      => $request->query('per_page'),
+            'uri'          => env('APP_URL') . $request->getPathInfo()
         ];
 
-        $totalCount = 9;
-        $link = '<http://127.0.0.1/api/stocks/categories/1?page=4&per_page=2>; rel="next", ';
-        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=5&per_page=2>; rel="last", ';
-        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=1&per_page=2>; rel="first", ';
-        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=2&per_page=2>; rel="prev"';
+        $response = $this->stockScenario->showCategorized($params);
 
         return response()
-            ->json($stocks)
+            ->json($response['stocks'])
             ->setStatusCode(200)
-            ->header('Total-Count', $totalCount)
-            ->header('Link', $link);
+            ->header('Total-Count', $response['totalCount'])
+            ->header('Link', $response['link']);
     }
 }

--- a/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
+++ b/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
@@ -7,6 +7,7 @@ namespace App\Infrastructure\Repositories\Api;
 
 use App\Models\Domain\Stock\StockValue;
 use App\Models\Domain\Stock\StockValues;
+use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Stock\FetchStockValues;
 use App\Models\Domain\Stock\StockValueBuilder;
 use App\Models\Domain\Category\CategoryStockEntities;
@@ -20,15 +21,15 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
     /**
      * ストック一覧を取得する
      *
-     * @param string $qiitaUserName
+     * @param AccountEntity $accountEntity
      * @param int $page
      * @param int $perPage
      * @return FetchStockValues
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function fetchStocks(string $qiitaUserName, int $page, int $perPage): FetchStockValues
+    public function fetchStocks(AccountEntity $accountEntity, int $page, int $perPage): FetchStockValues
     {
-        $response = $this->requestToStockApi($qiitaUserName, $page, $perPage);
+        $response = $this->requestToStockApi($accountEntity->getUserName(), $accountEntity->getAccessToken(), $page, $perPage);
 
         $responseArray = json_decode($response->getBody());
 
@@ -47,12 +48,13 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
      * Stock APIにリクエストを行う
      *
      * @param string $qiitaUserName
+     * @param string $accessToken
      * @param int $page
      * @param int $perPage
      * @return mixed|\Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function requestToStockApi(string $qiitaUserName, int $page, int $perPage)
+    private function requestToStockApi(string $qiitaUserName, string $accessToken, int $page, int $perPage)
     {
         $uri = sprintf(
             'https://qiita.com/api/v2/users/%s/stocks?page=%d&per_page=%d',
@@ -61,7 +63,11 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
             $perPage
         );
 
-        return $this->getClient()->request('GET', $uri);
+        return $this->getClient()->request(
+            'GET',
+            $uri,
+            ['headers' => ['Authorization' => 'Bearer '. $accessToken]]
+        );
     }
 
     /**
@@ -105,17 +111,22 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
     /**
      * アイテム一覧を取得する
      *
+     * @param AccountEntity $accountEntity
      * @param CategoryStockEntities $categoryStockEntities
      * @return StockValues
      */
-    public function fetchItems(CategoryStockEntities $categoryStockEntities): StockValues
+    public function fetchItems(AccountEntity $accountEntity, CategoryStockEntities $categoryStockEntities): StockValues
     {
         $stockArticleIdList = $categoryStockEntities->buildArticleIdList();
 
         $promises = [];
         foreach ($stockArticleIdList as $stockArticleId) {
             $uri = sprintf('https://qiita.com/api/v2/items/%s', $stockArticleId);
-            $promises[] = $this->getClient()->requestAsync('GET', $uri);
+            $promises[] = $this->getClient()->requestAsync(
+                'GET',
+                $uri,
+                ['headers' => ['Authorization' => 'Bearer '. $accountEntity->getAccessToken()]]
+            );
         }
 
         $responses = \GuzzleHttp\Promise\all($promises)->wait();

--- a/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
+++ b/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
@@ -134,10 +134,7 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
         $stockValues = [];
         foreach ($responses as $response) {
             $stock = json_decode($response->getBody());
-
-
             $stockValue = $this->buildStockValue($stock);
-
             array_push($stockValues, $stockValue);
         }
 

--- a/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
+++ b/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
@@ -117,11 +117,8 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
             $uri = sprintf('https://qiita.com/api/v2/items/%s', $stockArticleId);
             $promises[] = $this->getClient()->requestAsync('GET', $uri);
         }
-        \Log::debug('犬');
 
         $responses = \GuzzleHttp\Promise\all($promises)->wait();
-
-        \Log::debug('猫');
 
         $stockValues = [];
         foreach ($responses as $response) {

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -249,4 +249,15 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
     {
         CategoryStock::destroy($categoryStockRelationList);
     }
+
+    /**
+     * カテゴリとストックのリレーションの件数を取得する
+     *
+     * @param string $categoryId
+     * @return int
+     */
+    public function getCountCategoriesStocksByCategoryId(string $categoryId): int
+    {
+        return CategoryStock::where('category_id', $categoryId)->count();
+    }
 }

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -12,7 +12,10 @@ use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryEntities;
 use App\Models\Domain\Category\CategoryNameValue;
+use App\Models\Domain\Category\CategoryStockEntity;
 use App\Models\Domain\Category\CategoryEntityBuilder;
+use App\Models\Domain\Category\CategoryStockEntities;
+use App\Models\Domain\Category\CategoryStockEntityBuilder;
 
 /**
  * Class CategoryRepository
@@ -175,18 +178,35 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
      * カテゴリとストックのリレーションを取得する
      *
      * @param CategoryEntity $categoryEntity
-     * @return array
+     * @return CategoryStockEntities
      */
-    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): array
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): CategoryStockEntities
     {
         $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())->get();
 
-        $stockArticleIds = $categoryStocks->map(function (CategoryStock $categoryStock): string {
-            return $categoryStock->article_id;
+        $categoryStockEntityList = $categoryStocks->map(function (CategoryStock $categoryStock): CategoryStockEntity {
+            return $this->buildCategoryStockEntity($categoryStock->toArray());
         });
 
-        return $stockArticleIds->toArray();
+        return new CategoryStockEntities(...$categoryStockEntityList->toArray());
     }
+
+    /**
+     * CategoryStockEntityを作成する
+     *
+     * @param array $categoryStock
+     * @return CategoryStockEntity
+     */
+    private function buildCategoryStockEntity(array $categoryStock): CategoryStockEntity
+    {
+        $categoryStockEntityBuilder = new CategoryStockEntityBuilder();
+        $categoryStockEntityBuilder->setId($categoryStock['id']);
+        $categoryStockEntityBuilder->setCategoryId($categoryStock['category_id']);
+        $categoryStockEntityBuilder->setArticleId($categoryStock['article_id']);
+
+        return $categoryStockEntityBuilder->build();
+    }
+
 
     /**
      * 指定したカテゴリ以外にカテゴライズされているストックのArticleID一覧を取得する

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -178,11 +178,20 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
      * カテゴリとストックのリレーションを取得する
      *
      * @param CategoryEntity $categoryEntity
+     * @param null $limit
+     * @param int $offset
      * @return CategoryStockEntities
      */
-    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): CategoryStockEntities
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity, $limit = null, $offset = 0): CategoryStockEntities
     {
-        $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())->get();
+        if ($limit === null) {
+            $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())->get();
+        } else {
+            $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())
+                ->offset($offset)
+                ->limit($limit)
+                ->get();
+        }
 
         $categoryStockEntityList = $categoryStocks->map(function (CategoryStock $categoryStock): CategoryStockEntity {
             return $this->buildCategoryStockEntity($categoryStock->toArray());

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -70,9 +70,9 @@ class CategoryEntity
      * カテゴリが持つストックのリストを取得する
      *
      * @param CategoryRepository $categoryRepository
-     * @return array
+     * @return CategoryStockEntities
      */
-    public function searchHadStockList(CategoryRepository $categoryRepository): array
+    public function searchHasCategoryStockEntities(CategoryRepository $categoryRepository): CategoryStockEntities
     {
         return $categoryRepository->searchCategoriesStocksByCategoryId($this);
     }
@@ -98,7 +98,8 @@ class CategoryEntity
      */
     private function createRelation(CategoryRepository $categoryRepository, array $articleIds)
     {
-        $stockArticleIdList = $this->searchHadStockList($categoryRepository);
+        $categoryStockEntities = $this->searchHasCategoryStockEntities($categoryRepository);
+        $stockArticleIdList = $categoryStockEntities->buildArticleIdList();
 
         $saveArticleIds = [];
         foreach ($articleIds as $articleId) {

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -70,11 +70,13 @@ class CategoryEntity
      * カテゴリが持つストックのリストを取得する
      *
      * @param CategoryRepository $categoryRepository
+     * @param int $limit
+     * @param int $offset
      * @return CategoryStockEntities
      */
-    public function searchHasCategoryStockEntities(CategoryRepository $categoryRepository): CategoryStockEntities
+    public function searchHasCategoryStockEntities(CategoryRepository $categoryRepository, $limit = null, $offset = 0): CategoryStockEntities
     {
-        return $categoryRepository->searchCategoriesStocksByCategoryId($this);
+        return $categoryRepository->searchCategoriesStocksByCategoryId($this, $limit, $offset);
     }
 
     /**

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -72,7 +72,7 @@ class CategoryEntity
      * @param CategoryRepository $categoryRepository
      * @return array
      */
-    private function searchHadStockList(CategoryRepository $categoryRepository): array
+    public function searchHadStockList(CategoryRepository $categoryRepository): array
     {
         return $categoryRepository->searchCategoriesStocksByCategoryId($this);
     }

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -65,9 +65,9 @@ interface CategoryRepository
      * カテゴリとストックのリレーションを取得する
      *
      * @param CategoryEntity $categoryEntity
-     * @return array
+     * @return CategoryStockEntities
      */
-    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): array;
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): CategoryStockEntities;
 
     /**
      * 指定したカテゴリ以外にカテゴライズされているストックのArticleID一覧を取得する

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -91,4 +91,12 @@ interface CategoryRepository
      * @param array $categoryStockRelationList
      */
     public function destroyCategoriesStocks(array $categoryStockRelationList);
+
+    /**
+     * カテゴリとストックのリレーションの件数を取得する
+     *
+     * @param string $categoryId
+     * @return int
+     */
+    public function getCountCategoriesStocksByCategoryId(string $categoryId): int;
 }

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -65,9 +65,11 @@ interface CategoryRepository
      * カテゴリとストックのリレーションを取得する
      *
      * @param CategoryEntity $categoryEntity
+     * @param null $limit
+     * @param int $offset
      * @return CategoryStockEntities
      */
-    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity): CategoryStockEntities;
+    public function searchCategoriesStocksByCategoryId(CategoryEntity $categoryEntity, $limit = null, $offset = 0): CategoryStockEntities;
 
     /**
      * 指定したカテゴリ以外にカテゴライズされているストックのArticleID一覧を取得する
@@ -77,7 +79,11 @@ interface CategoryRepository
      * @param array $articleIdList
      * @return array
      */
-    public function searchCategoriesStocksByArticleId(AccountEntity $accountEntity, CategoryEntity $categoryEntity, array $articleIdList): array;
+    public function searchCategoriesStocksByArticleId(
+        AccountEntity $accountEntity,
+        CategoryEntity $categoryEntity,
+        array $articleIdList
+    ): array;
 
     /**
      * カテゴリとストックのリレーションを削除する

--- a/app/Models/Domain/Category/CategoryStockEntities.php
+++ b/app/Models/Domain/Category/CategoryStockEntities.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CategoryStockEntities
+ */
+
+namespace App\Models\Domain\Category;
+
+/**
+ * Class CategoryStockEntities
+ * @package App\Models\Domain\Category
+ */
+class CategoryStockEntities
+{
+    /**
+     *
+     * @var CategoryStockEntity[]
+     */
+    private $categoryStockEntities;
+
+    /**
+     * CategoryStockEntities constructor.
+     * @param CategoryStockEntity ...$categoryStockEntities
+     */
+    public function __construct(CategoryStockEntity ...$categoryStockEntities)
+    {
+        $this->categoryStockEntities = $categoryStockEntities;
+    }
+
+    /**
+     * @return CategoryStockEntity[]
+     */
+    public function getCategoryStockEntities(): array
+    {
+        return $this->categoryStockEntities;
+    }
+
+    /**
+     * ArticleIDリストを生成する
+     *
+     * @return array
+     */
+    public function buildArticleIdList(): array
+    {
+        $categoryStockEntityList = $this->getCategoryStockEntities();
+
+        $stockArticleIdList = [];
+        foreach ($categoryStockEntityList as $categoryStockEntity) {
+            array_push($stockArticleIdList, $categoryStockEntity->getArticleId());
+        }
+        return $stockArticleIdList;
+    }
+}

--- a/app/Models/Domain/Category/CategoryStockEntity.php
+++ b/app/Models/Domain/Category/CategoryStockEntity.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * CategoryStockEntity
+ */
+
+namespace App\Models\Domain\Category;
+
+class CategoryStockEntity
+{
+    /**
+     * カテゴリID
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * カテゴリID
+     *
+     * @var int
+     */
+    private $categoryId;
+
+    /**
+     * Article ID
+     *
+     * @var string
+     */
+    private $articleId;
+
+    /**
+     * CategoryStockEntity constructor.
+     * @param CategoryStockEntityBuilder $builder
+     */
+    public function __construct(CategoryStockEntityBuilder $builder)
+    {
+        $this->id = $builder->getId();
+        $this->categoryId = $builder->getCategoryId();
+        $this->articleId = $builder->getArticleId();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getArticleId(): string
+    {
+        return $this->articleId;
+    }
+}

--- a/app/Models/Domain/Category/CategoryStockEntityBuilder.php
+++ b/app/Models/Domain/Category/CategoryStockEntityBuilder.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * CategoryStockEntityBuilder
+ */
+
+namespace App\Models\Domain\Category;
+
+/**
+ * Class CategoryStockEntityBuilder
+ * @package App\Models\Domain\Category
+ */
+class CategoryStockEntityBuilder
+{
+    /**
+     * カテゴリID
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * カテゴリID
+     *
+     * @var int
+     */
+    private $categoryId;
+
+    /**
+     * Article ID
+     *
+     * @var string
+     */
+    private $articleId;
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+
+    /**
+     * @param int $categoryId
+     */
+    public function setCategoryId(int $categoryId): void
+    {
+        $this->categoryId = $categoryId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getArticleId(): string
+    {
+        return $this->articleId;
+    }
+
+    /**
+     * @param string $articleId
+     */
+    public function setArticleId(string $articleId): void
+    {
+        $this->articleId = $articleId;
+    }
+
+    public function build()
+    {
+        return new CategoryStockEntity($this);
+    }
+}

--- a/app/Models/Domain/QiitaApiRepository.php
+++ b/app/Models/Domain/QiitaApiRepository.php
@@ -6,6 +6,7 @@
 namespace App\Models\Domain;
 
 use App\Models\Domain\Stock\StockValues;
+use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Stock\FetchStockValues;
 use App\Models\Domain\Category\CategoryStockEntities;
 
@@ -18,18 +19,19 @@ interface QiitaApiRepository
     /**
      * ストック一覧を取得する
      *
-     * @param string $qiitaUserName
+     * @param AccountEntity $accountEntity
      * @param int $page
      * @param int $perPage
      * @return FetchStockValues
      */
-    public function fetchStocks(string $qiitaUserName, int $page, int $perPage): FetchStockValues;
+    public function fetchStocks(AccountEntity $accountEntity, int $page, int $perPage): FetchStockValues;
 
     /**
      * アイテム一覧を取得する
      *
+     * @param AccountEntity $accountEntity
      * @param CategoryStockEntities $categoryStockEntities
      * @return StockValues
      */
-    public function fetchItems(CategoryStockEntities $categoryStockEntities): StockValues;
+    public function fetchItems(AccountEntity $accountEntity, CategoryStockEntities $categoryStockEntities): StockValues;
 }

--- a/app/Models/Domain/QiitaApiRepository.php
+++ b/app/Models/Domain/QiitaApiRepository.php
@@ -5,7 +5,9 @@
 
 namespace App\Models\Domain;
 
+use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Stock\FetchStockValues;
+use App\Models\Domain\Category\CategoryStockEntities;
 
 /**
  * Interface QiitaApiRepository
@@ -21,5 +23,13 @@ interface QiitaApiRepository
      * @param int $perPage
      * @return FetchStockValues
      */
-    public function fetchStock(string $qiitaUserName, int $page, int $perPage): FetchStockValues;
+    public function fetchStocks(string $qiitaUserName, int $page, int $perPage): FetchStockValues;
+
+    /**
+     * アイテム一覧を取得する
+     *
+     * @param CategoryStockEntities $categoryStockEntities
+     * @return StockValues
+     */
+    public function fetchItems(CategoryStockEntities $categoryStockEntities): StockValues;
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -101,7 +101,8 @@ class AppServiceProvider extends ServiceProvider
                     $this->app->make(AccountRepository::class),
                     $this->app->make(LoginSessionRepository::class),
                     $this->app->make(StockRepository::class),
-                    $this->app->make(QiitaApiRepository::class)
+                    $this->app->make(QiitaApiRepository::class),
+                    $this->app->make(CategoryRepository::class)
                 );
             }
         );

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -73,13 +73,6 @@ class StockScenario
      * @param LoginSessionRepository $loginSessionRepository
      * @param StockRepository $stockRepository
      * @param QiitaApiRepository $qiitaApiRepository
-     */
-    /**
-     * StockScenario constructor.
-     * @param AccountRepository $accountRepository
-     * @param LoginSessionRepository $loginSessionRepository
-     * @param StockRepository $stockRepository
-     * @param QiitaApiRepository $qiitaApiRepository
      * @param CategoryRepository $categoryRepository
      */
     public function __construct(
@@ -212,8 +205,11 @@ class StockScenario
             $offset = ($params['page'] - 1) * $limit;
 
             $categoryStockEntities = $categoryEntity->searchHasCategoryStockEntities($this->categoryRepository, $limit, $offset);
+            $totalCount = $this->categoryRepository->getCountCategoriesStocksByCategoryId($categoryEntity->getId());
 
             $stockValues = $this->qiitaApiRepository->fetchItems($categoryStockEntities);
+
+            // TODO APIでエラーが返ってきた場合の処理
         } catch (ModelNotFoundException $e) {
             throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
         } catch (\PDOException $e) {
@@ -222,7 +218,7 @@ class StockScenario
         }
 
         $stockValueList = $stockValues->getStockValues();
-        $totalCount = count($stockValueList);
+
         $linkList = $this->buildLinkHeaderList($params['uri'], $params['page'], $params['perPage'], $totalCount);
         $link = implode(', ', $linkList);
 

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -184,6 +184,7 @@ class StockScenario
      * @param array $params
      * @return array
      * @throws CategoryNotFoundException
+     * @throws ServiceUnavailableException
      * @throws UnauthorizedException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      */
@@ -208,10 +209,10 @@ class StockScenario
             $totalCount = $this->categoryRepository->getCountCategoriesStocksByCategoryId($categoryEntity->getId());
 
             $stockValues = $this->qiitaApiRepository->fetchItems($categoryStockEntities);
-
-            // TODO APIでエラーが返ってきた場合の処理
         } catch (ModelNotFoundException $e) {
             throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
+        } catch (RequestException $e) {
+            throw new ServiceUnavailableException();
         } catch (\PDOException $e) {
             \DB::rollBack();
             throw $e;

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -165,6 +165,66 @@ class StockScenario
     }
 
     /**
+     * カテゴライズされたストック一覧を取得する
+     *
+     * @param array $params
+     * @return array
+     * @throws UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
+     */
+    public function showCategorized(array $params): array
+    {
+        try {
+            // TODO カテゴリID, page, perPage のバリデーション
+
+            $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
+
+            // TODO カテゴリIDからカテゴリとストックのリレーションを取得する
+        } catch (ModelNotFoundException $e) {
+            throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
+        } catch (\PDOException $e) {
+            throw $e;
+        }
+
+
+
+        $stocks = [
+            [
+                'id'                       => '1',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル',
+                'user_id'                  => 'test-user',
+                'profile_image_url'        => 'http://test.com/test-image.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ],
+            [
+                'id'                       => '2',
+                'article_id'               => '1234567890abcdefghij',
+                'title'                    => 'タイトル2',
+                'user_id'                  => 'test-user2',
+                'profile_image_url'        => 'http://test.com/test-image2.jpag',
+                'article_created_at'       => '2018-12-01 00:00:00.000000',
+                'tags'                     => ['laravel5.6', 'laravel', 'php']
+            ]
+        ];
+
+        $totalCount = 9;
+        $link = '<http://127.0.0.1/api/stocks/categories/1?page=4&per_page=2>; rel="next", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=5&per_page=2>; rel="last", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=1&per_page=2>; rel="first", ';
+        $link .= '<http://127.0.0.1/api/stocks/categories/1?page=2&per_page=2>; rel="prev"';
+
+        $response = [
+            'stocks'     => $stocks,
+            'totalCount' => $totalCount,
+            'link'       => $link
+        ];
+
+        return $response;
+    }
+
+    /**
      * Linkヘッダーのリストを作成する
      *
      * @param string $uriBase

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -141,7 +141,7 @@ class StockScenario
 
             $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
 
-            $fetchStocksValue = $this->qiitaApiRepository->fetchStocks($accountEntity->getUserName(), $params['page'], $params['perPage']);
+            $fetchStocksValue = $this->qiitaApiRepository->fetchStocks($accountEntity, $params['page'], $params['perPage']);
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         } catch (RequestException $e) {
@@ -208,7 +208,7 @@ class StockScenario
             $categoryStockEntities = $categoryEntity->searchHasCategoryStockEntities($this->categoryRepository, $limit, $offset);
             $totalCount = $this->categoryRepository->getCountCategoriesStocksByCategoryId($categoryEntity->getId());
 
-            $stockValues = $this->qiitaApiRepository->fetchItems($categoryStockEntities);
+            $stockValues = $this->qiitaApiRepository->fetchItems($accountEntity, $categoryStockEntities);
         } catch (ModelNotFoundException $e) {
             throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
         } catch (RequestException $e) {

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -208,8 +208,10 @@ class StockScenario
         try {
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
-            // TODO pageとperPageを指定する
-            $categoryStockEntities = $categoryEntity->searchHasCategoryStockEntities($this->categoryRepository);
+            $limit = $params['perPage'];
+            $offset = ($params['page'] - 1) * $limit;
+
+            $categoryStockEntities = $categoryEntity->searchHasCategoryStockEntities($this->categoryRepository, $limit, $offset);
 
             $stockValues = $this->qiitaApiRepository->fetchItems($categoryStockEntities);
         } catch (ModelNotFoundException $e) {

--- a/tests/Feature/StockIndexTest.php
+++ b/tests/Feature/StockIndexTest.php
@@ -63,8 +63,8 @@ class StockIndexTest extends AbstractTestCase
 
         $fetchStockList = [];
         foreach ($stockList as $stock) {
-            $fetchStoc = $this->createFetchStocksData($stock);
-            array_push($fetchStockList, $fetchStoc);
+            $fetchStock = $this->createFetchStocksData($stock);
+            array_push($fetchStockList, $fetchStock);
         }
 
         $mockData = [[200, ['total-count' => $stockCount], json_encode($fetchStockList)]];

--- a/tests/Feature/StockIndexTest.php
+++ b/tests/Feature/StockIndexTest.php
@@ -15,7 +15,6 @@ use App\Eloquents\CategoryName;
 use App\Eloquents\LoginSession;
 use App\Eloquents\QiitaAccount;
 use App\Eloquents\QiitaUserName;
-
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**

--- a/tests/Feature/StockShowCategorizedTest.php
+++ b/tests/Feature/StockShowCategorizedTest.php
@@ -107,6 +107,40 @@ class StockShowCategorizedTest extends AbstractTestCase
 
     /**
      * 異常系のテスト
+     * 指定したカテゴリがアカウントに紐づかない場合エラーとなること
+     */
+    public function testErrorCategoryNotFound()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $categoryId = 2;
+        $page = 2;
+        $perPage = 2;
+
+        $uri = sprintf(
+            '/api/stocks/categories/%d?page=%d&per_page=%d',
+            $categoryId,
+            $page,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 404;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
      * Authorizationが存在しない場合エラーとなること
      */
     public function testErrorLoginSessionNull()

--- a/tests/Feature/StockShowCategorizedTest.php
+++ b/tests/Feature/StockShowCategorizedTest.php
@@ -51,16 +51,18 @@ class StockShowCategorizedTest extends AbstractTestCase
         $categoryId = 1;
         factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
 
-        $page = 1;
-        $perPage = 20;
+        $page = 3;
+        $perPage = 10;
+        $totalCount = 45;
         $idSequence = 1;
 
-        $stockList = $this->createStocks($perPage, $idSequence);
+        $stockList = $this->createStocks($totalCount, $idSequence);
 
         foreach ($stockList as $stock) {
             factory(CategoryStock::class)->create(['category_id' => $categoryId, 'article_id' => $stock['article_id']]);
         }
 
+        $stockList = array_slice($stockList, 20, $perPage);
         $mockData = [];
         foreach ($stockList as $stock) {
             $fetchStock = $this->createFetchStocksData($stock);
@@ -80,20 +82,19 @@ class StockShowCategorizedTest extends AbstractTestCase
             ['Authorization' => 'Bearer ' . $loginSession]
         );
 
-        $link = sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=3&per_page=%d>; rel="next", ', $categoryId, $perPage);
+        $link = sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=4&per_page=%d>; rel="next", ', $categoryId, $perPage);
         $link .= sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=5&per_page=%d>; rel="last", ', $categoryId, $perPage);
         $link .= sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=1&per_page=%d>; rel="first", ', $categoryId, $perPage);
-        $link .= sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=1&per_page=%d>; rel="prev"', $categoryId, $perPage);
+        $link .= sprintf('<http://127.0.0.1/api/stocks/categories/%d?page=2&per_page=%d>; rel="prev"', $categoryId, $perPage);
 
 
         // 実際にJSONResponseに期待したデータが含まれているか確認する
         $jsonResponse->assertJson($stockList);
         $jsonResponse->assertStatus(200);
         $jsonResponse->assertHeader('X-Request-Id');
-//        $jsonResponse->assertHeader('Link', $link);
-        $jsonResponse->assertHeader('Total-Count', $perPage);
+        $jsonResponse->assertHeader('Link', $link);
+        $jsonResponse->assertHeader('Total-Count', $totalCount);
     }
-
 
     /**
      * ストックのデータを作成する


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/116

# Doneの定義
- 指定したカテゴリにカテゴライズされたストック一覧が取得できること

# 変更点概要

## 仕様的変更点概要
カテゴライズされたストック一覧を返すように修正。

## 技術的変更点概要
- 新規に`CategoryStockEntity`を作成
- `StockScenario`シナリオクラスに、認証処理を追加
- `StockScenario`シナリオクラスに、カテゴリIDから`CategoryStockEntity`のリストを取得し、QiitaAPIから記事の情報を取得する処理を追加
- QiitaAPIへのリクエストに、`Authorization`ヘッダを含めるように修正
  -> https://github.com/nekochans/qiita-stocker-backend/issues/114 で作成したストック取得APIについても未対応だったので合わせて対応

# 補足情報
バリデーションについては次のPRで対応予定。

# 相談
QiitaAPIへ同時に複数のリクエストするために`\GuzzleHttp\Promise\all`を使用しているが、QiitaAPIから1件でもエラーとなった場合、エラーレスポンスを返している。
ストックしていた記事が削除されたケースなどを想定すると、エラーレスポンスを返すのではなく、正常に取得できたストックの一覧を返すように修正した方がいいか。