### PR TITLE
バリデーションを追加

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -89,6 +89,7 @@ class StockController extends Controller
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
      */
     public function showCategorized(Request $request): JsonResponse
     {

--- a/app/Models/Domain/Stock/StockSpecification.php
+++ b/app/Models/Domain/Stock/StockSpecification.php
@@ -17,11 +17,32 @@ class StockSpecification
      * @param array $requestArray
      * @return array
      */
-    public static function canfetchStocks(array $requestArray): array
+    public static function canFetchStocks(array $requestArray): array
     {
         $validator = \Validator::make($requestArray, [
             'page'       => 'required|integer|min:1|max:100',
             'perPage'    => 'required|integer|min:1|max:100',
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->toArray();
+        }
+        return [];
+    }
+
+
+    /**
+     * カテゴライズ済みのストックが検索可能か確認する
+     *
+     * @param array $requestArray
+     * @return array
+     */
+    public static function canFetchCategorizedStocks(array $requestArray): array
+    {
+        $validator = \Validator::make($requestArray, [
+            'page'       => 'required|integer|min:1|max:100',
+            'perPage'    => 'required|integer|min:1|max:100',
+            'id'         => 'required|integer|min:1|max:18446744073709551615' // 符号無しBIGINTの最大値
         ]);
 
         if ($validator->fails()) {

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -134,7 +134,7 @@ class StockScenario
     public function index(array $params): array
     {
         try {
-            $errors = StockSpecification::canfetchStocks($params);
+            $errors = StockSpecification::canFetchStocks($params);
             if ($errors) {
                 throw new ValidationException(StockEntities::searchStocksErrorMessage(), $errors);
             }
@@ -186,12 +186,17 @@ class StockScenario
      * @throws CategoryNotFoundException
      * @throws ServiceUnavailableException
      * @throws UnauthorizedException
+     * @throws ValidationException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
      */
     public function showCategorized(array $params): array
     {
         try {
-            // TODO カテゴリID, page, perPage のバリデーション
+            $errors = StockSpecification::canFetchCategorizedStocks($params);
+            if ($errors) {
+                throw new ValidationException(StockEntities::searchStocksErrorMessage(), $errors);
+            }
+
             $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());

--- a/tests/Feature/StockShowCategorizedTest.php
+++ b/tests/Feature/StockShowCategorizedTest.php
@@ -337,4 +337,171 @@ class StockShowCategorizedTest extends AbstractTestCase
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
+
+    /**
+     * 異常系のテスト
+     * ストック取得時のクエリパラメータ page のバリデーション
+     *
+     * @param $page
+     * @dataProvider pageProvider
+     */
+    public function testErrorPageValidation($page)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        $categoryId = 1;
+        $perPage = 20;
+
+        $uri = sprintf(
+            '/api/stocks/categories/%d?page=%s&per_page=%d',
+            $categoryId,
+            $page,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * page のデータプロバイダ
+     *
+     * @return array
+     */
+    public function pageProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'string'             => ['a'],
+            'symbol'             => ['1/'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [101],
+        ];
+    }
+
+    /**
+     * 異常系のテスト
+     * ストック取得時のクエリパラメータ perPage のバリデーション
+     *
+     * @param $perPage
+     * @dataProvider perPageProvider
+     */
+    public function testErrorPerPageValidation($perPage)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        $categoryId = 1;
+        $page = 1;
+
+        $uri = sprintf(
+            '/api/stocks/categories/%d?page=%d&per_page=%s',
+            $categoryId,
+            $page,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * perPage のデータプロバイダ
+     *
+     * @return array
+     */
+    public function perPageProvider()
+    {
+        return [
+            'emptyString'        => [''],
+            'null'               => [null],
+            'string'             => ['a'],
+            'symbol'             => ['1;'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [101],
+        ];
+    }
+
+    /**
+     * 異常系のテスト
+     * カテゴリ更新時のカテゴリIDのバリデーション
+     *
+     * @param $categoryId
+     * @dataProvider categoryIdProvider
+     */
+    public function testErrorCategoryIdValidation($categoryId)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $page = 1;
+        $perPage = 20;
+
+        $uri = sprintf(
+            '/api/stocks/categories/%s?page=%d&per_page=%d',
+            $categoryId,
+            $page,
+            $perPage
+        );
+
+        $jsonResponse = $this->get(
+            $uri,
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * カテゴリIDのデータプロバイダ
+     *
+     * @return array
+     */
+    public function categoryIdProvider()
+    {
+        // カテゴリIDが設定されていない場合はルーティングされないので考慮しない
+        return [
+            'string'             => ['a'],
+            'symbol'             => ['1@'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [18446744073709551615],
+        ];
+    }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/116

# Doneの定義
- バリデーションが追加されていること

# 変更点概要

## 仕様的変更点概要
バリデーションを下記の通り設定。
- page : 1から100まで
- per_page : 1から100まで
- categoryId : 1から符号無しBIGINTの最大値まで 
　(https://github.com/nekochans/qiita-stocker-backend/pull/86 カテゴリ編集APIで設定しているカテゴリIDのバリデーションと同じ)

```
HTTP/1.1 422 Unprocessable Entity
{
  "code":422,
  "message":"不正なリクエストが行われました。",
  "errors":{"page":["The page field is required."]}
}
```
`errors`は、Laravelのバリデーションメッセージ

## 技術的変更点概要
仕様クラス`StockSpecification`に、カテゴライズ済みのストック取得時のバリデーションを追加。