### PR TITLE
カテゴリ削除APIのIFを定義する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -101,6 +101,25 @@ class CategoryController extends Controller
         return response()->json($category)->setStatusCode(200);
     }
 
+    /**
+     * カテゴリを削除する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        $requestArray = $request->json()->all();
+
+        $sessionId = $request->bearerToken();
+        $params = [
+            'sessionId' => $sessionId
+        ];
+
+        $params = array_merge($params, $requestArray);
+
+        return response()->json()->setStatusCode(204);
+    }
 
     /**
      * 指定されたカテゴリとストックのリレーションを作成する

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,8 @@ Route::middleware(['cors', 'xRequestId'])->group(function () {
 
     Route::patch('categories/{id}', 'CategoryController@update');
 
+    Route::delete('categories/{id}', 'CategoryController@destroy');
+
     Route::options('stocks', function () {
         return response()->json();
     });

--- a/tests/Feature/CategoryDestroyTest.php
+++ b/tests/Feature/CategoryDestroyTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CategoryDestroyTest
+ */
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class CategoryDestroyTest
+ * @package Tests\Feature
+ */
+class CategoryDestroyTest extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系のテスト
+     * カテゴリを削除できること
+     */
+    public function testSuccess()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $categoryId = 1;
+
+        $jsonResponse = $this->delete(
+            '/api/categories/'. $categoryId,
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/104

# Doneの定義
- IFが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴリ削除APIのIFを定義
`DELETE api/categories/{id}`

リクエスト
```
curl -X DELETE -kv \
-H "Authorization: Bearer 04844f4a-d051-4467-9e6f-911d765e5359" \
http://127.0.0.1/api/categories/1
```

HTTPレスポンスHeader
```
HTTP/1.1 204 No Content
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```

## 技術的変更点概要
ルーティングを設定。