### PR TITLE
カテゴリ削除処理を作成する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -113,15 +113,14 @@ class CategoryController extends Controller
      */
     public function destroy(Request $request): JsonResponse
     {
-        $requestArray = $request->json()->all();
-
         $sessionId = $request->bearerToken();
         $params = [
-            'sessionId' => $sessionId
+            'sessionId'    => $sessionId,
+            'id'           => $request->id,
         ];
-        $params = array_merge($params, $requestArray);
 
         $this->categoryScenario->destroy($params);
+        
         return response()->json()->setStatusCode(204);
     }
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -106,6 +106,10 @@ class CategoryController extends Controller
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
+     * @throws \App\Models\Domain\Exceptions\UnauthorizedException
+     * @throws \App\Models\Domain\Exceptions\ValidationException
+     * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException
      */
     public function destroy(Request $request): JsonResponse
     {
@@ -115,9 +119,9 @@ class CategoryController extends Controller
         $params = [
             'sessionId' => $sessionId
         ];
-
         $params = array_merge($params, $requestArray);
 
+        $this->categoryScenario->destroy($params);
         return response()->json()->setStatusCode(204);
     }
 

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -125,6 +125,17 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
     }
 
     /**
+     * カテゴリを削除する
+     * @param CategoryEntity $categoryEntity
+     */
+    public function destroy(CategoryEntity $categoryEntity)
+    {
+        CategoryName::where('category_id', $categoryEntity->getId())->delete();
+        CategoryStock::where('category_id', $categoryEntity->getId())->delete();
+        Category::destroy($categoryEntity->getId());
+    }
+
+    /**
      * カテゴリを取得する
      *
      * @param string $categoryId

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -38,6 +38,12 @@ interface CategoryRepository
     public function destroyAll(string $accountId);
 
     /**
+     * カテゴリを削除する
+     * @param CategoryEntity $categoryEntity
+     */
+    public function destroy(CategoryEntity $categoryEntity);
+
+    /**
      * カテゴリを取得する
      *
      * @param string $categoryId

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -222,7 +222,7 @@ class CategoryScenario
 
             \DB::beginTransaction();
 
-            // TODO カテゴリの削除処理
+            $this->categoryRepository->destroy($categoryEntity);
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -194,6 +194,24 @@ class CategoryScenario
     }
 
     /**
+     * カテゴリを削除する
+     *
+     * @param array $params
+     * @throws LoginSessionExpiredException
+     * @throws UnauthorizedException
+     */
+    public function destroy(array $params)
+    {
+        try {
+            $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
+        } catch (ModelNotFoundException $e) {
+            throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
+        } catch (\PDOException $e) {
+            throw $e;
+        }
+    }
+
+    /**
      * カテゴリとストックのリレーションを作成する
      *
      * @param array $params

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -197,6 +197,7 @@ class CategoryScenario
      * カテゴリを削除する
      *
      * @param array $params
+     * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
      */
@@ -207,6 +208,21 @@ class CategoryScenario
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         } catch (\PDOException $e) {
+            throw $e;
+        }
+
+        try {
+            $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
+
+            \DB::beginTransaction();
+
+            // TODO カテゴリの削除処理
+
+            \DB::commit();
+        } catch (ModelNotFoundException $e) {
+            throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
+        } catch (\PDOException $e) {
+            \DB::rollBack();
             throw $e;
         }
     }

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -200,6 +200,7 @@ class CategoryScenario
      * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
      * @throws UnauthorizedException
+     * @throws ValidationException
      */
     public function destroy(array $params)
     {
@@ -212,6 +213,11 @@ class CategoryScenario
         }
 
         try {
+            $errors = CategorySpecification::canSetCategoryEntityId($params);
+            if ($errors) {
+                throw new ValidationException(CategoryEntity::categoryIdValidationErrorMessage(), $errors);
+            }
+
             $categoryEntity = $accountEntity->findHasCategoryEntity($this->categoryRepository, $params['id']);
 
             \DB::beginTransaction();

--- a/tests/Feature/AccountDestroyTest.php
+++ b/tests/Feature/AccountDestroyTest.php
@@ -71,7 +71,6 @@ class AccountDestroyTest extends AbstractTestCase
         $jsonResponse->assertStatus(204);
         $jsonResponse->assertHeader('X-Request-Id');
 
-
         // DBのテーブルに期待した形でデータが入っているか確認する
         $this->assertDatabaseMissing('accounts', [
             'id'           => $destroyedAccountId,

--- a/tests/Feature/CategoryDestroyTest.php
+++ b/tests/Feature/CategoryDestroyTest.php
@@ -177,4 +177,50 @@ class CategoryDestroyTest extends AbstractTestCase
         $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
+
+    /**
+     * 異常系のテスト
+     * カテゴリ更新時のカテゴリIDのバリデーション
+     *
+     * @param $categoryId
+     * @dataProvider categoryIdProvider
+     */
+    public function testErrorCategoryIdValidation($categoryId)
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $jsonResponse = $this->delete(
+            '/api/categories/'. $categoryId,
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 422;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * カテゴリIDのデータプロバイダ
+     *
+     * @return array
+     */
+    public function categoryIdProvider()
+    {
+        // カテゴリIDが設定されていない場合はルーティングされないので考慮しない
+        return [
+            'string'             => ['a'],
+            'symbol'             => ['1@'],
+            'multiByte'          => ['１'],
+            'negativeNumber'     => [-1],
+            'double'             => [1.1],
+            'lessThanMin'        => [0],
+            'greaterThanMax'     => [18446744073709551615],
+        ];
+    }
 }

--- a/tests/Feature/CategoryDestroyTest.php
+++ b/tests/Feature/CategoryDestroyTest.php
@@ -46,9 +46,20 @@ class CategoryDestroyTest extends AbstractTestCase
      */
     public function testSuccess()
     {
+        $otherAccountId = 2;
+        $otherCategoryId = 2;
+        factory(Account::class)->create();
+        factory(QiitaAccount::class)->create(['qiita_account_id' => 2, 'account_id' => $otherAccountId]);
+        factory(QiitaUserName::class)->create(['account_id' => $otherAccountId]);
+        factory(AccessToken::class)->create(['account_id' => $otherAccountId]);
+        factory(LoginSession::class)->create(['account_id' => $otherAccountId]);
+        factory(Category::class)->create(['account_id' => $otherAccountId]);
+        factory(CategoryName::class)->create(['category_id' => $otherCategoryId]);
+        factory(CategoryStock::class)->create(['category_id' => $otherCategoryId]);
+
         $categoryId = 1;
-        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
         $accountId = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
         factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
 
         $jsonResponse = $this->delete(
@@ -59,6 +70,28 @@ class CategoryDestroyTest extends AbstractTestCase
 
         $jsonResponse->assertStatus(204);
         $jsonResponse->assertHeader('X-Request-Id');
+
+        // DBのテーブルに期待した形でデータが入っているか確認する
+        $this->assertDatabaseMissing('categories', [
+            'account_id'   => $accountId,
+        ]);
+        $this->assertDatabaseHas('categories', [
+            'account_id'   => $otherAccountId,
+        ]);
+
+        $this->assertDatabaseMissing('categories_names', [
+            'category_id'   => $categoryId,
+        ]);
+        $this->assertDatabaseHas('categories_names', [
+            'category_id'   => $otherCategoryId,
+        ]);
+
+        $this->assertDatabaseMissing('categories_stocks', [
+            'category_id'   => $categoryId,
+        ]);
+        $this->assertDatabaseHas('categories_stocks', [
+            'category_id'   => $otherCategoryId,
+        ]);
     }
 
     /**

--- a/tests/Feature/CategoryDestroyTest.php
+++ b/tests/Feature/CategoryDestroyTest.php
@@ -61,6 +61,54 @@ class CategoryDestroyTest extends AbstractTestCase
         $jsonResponse->assertHeader('X-Request-Id');
     }
 
+    /**
+     * 異常系のテスト
+     * カテゴリが見つからない場合エラーとなること
+     */
+    public function testErrorCategoryIdNotFound()
+    {
+        $otherAccountId = 2;
+        $otherCategoryId = 2;
+
+        factory(Account::class)->create();
+        factory(QiitaAccount::class)->create(['qiita_account_id' => 2, 'account_id' => $otherAccountId]);
+        factory(QiitaUserName::class)->create(['account_id' => $otherAccountId]);
+        factory(AccessToken::class)->create(['account_id' => $otherAccountId]);
+        factory(LoginSession::class)->create(['account_id' => $otherAccountId]);
+        factory(Category::class)->create(['account_id' => $otherAccountId]);
+        factory(CategoryName::class)->create(['category_id' => $otherCategoryId]);
+        factory(CategoryStock::class)->create(['category_id' => $otherCategoryId]);
+
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+
+        $jsonResponse = $this->delete(
+            '/api/categories/'. $otherCategoryId,
+            [],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 404;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => '不正なリクエストが行われました。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+
+        // DBのテーブルに期待した形でデータが入っているか確認する
+        $this->assertDatabaseHas('categories', [
+            'account_id'   => $otherAccountId,
+        ]);
+
+        $this->assertDatabaseHas('categories_names', [
+            'category_id'   => $otherCategoryId,
+        ]);
+
+        $this->assertDatabaseHas('categories_stocks', [
+            'category_id'   => $otherCategoryId,
+        ]);
+    }
 
     /**
      * 異常系のテスト

--- a/tests/Feature/CategoryDestroyTest.php
+++ b/tests/Feature/CategoryDestroyTest.php
@@ -5,6 +5,14 @@
 
 namespace Tests\Feature;
 
+use App\Eloquents\Account;
+use App\Eloquents\Category;
+use App\Eloquents\AccessToken;
+use App\Eloquents\CategoryName;
+use App\Eloquents\LoginSession;
+use App\Eloquents\QiitaAccount;
+use App\Eloquents\CategoryStock;
+use App\Eloquents\QiitaUserName;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
@@ -15,14 +23,33 @@ class CategoryDestroyTest extends AbstractTestCase
 {
     use RefreshDatabase;
 
+    public function setUp()
+    {
+        parent::setUp();
+        $accounts = factory(Account::class)->create();
+        $accounts->each(function ($account) {
+            factory(QiitaAccount::class)->create(['account_id' => $account->id]);
+            factory(QiitaUserName::class)->create(['account_id' => $account->id]);
+            factory(AccessToken::class)->create(['account_id' => $account->id]);
+            factory(LoginSession::class)->create(['account_id' => $account->id]);
+            $categories = factory(Category::class)->create(['account_id' => $account->id]);
+            $categories->each(function ($category) {
+                factory(CategoryName::class)->create(['category_id' => $category->id]);
+                factory(CategoryStock::class)->create(['category_id' => $category->id]);
+            });
+        });
+    }
+
     /**
      * 正常系のテスト
      * カテゴリを削除できること
      */
     public function testSuccess()
     {
-        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
         $categoryId = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
 
         $jsonResponse = $this->delete(
             '/api/categories/'. $categoryId,
@@ -31,6 +58,75 @@ class CategoryDestroyTest extends AbstractTestCase
         );
 
         $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+
+    /**
+     * 異常系のテスト
+     * Authorizationが存在しない場合エラーとなること
+     */
+    public function testErrorLoginSessionNull()
+    {
+        $categoryId = 1;
+        $jsonResponse = $this->delete('/api/categories/'. $categoryId);
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが不正の場合エラーとなること
+     */
+    public function testErrorLoginSessionNotFound()
+    {
+        $loginSession = 'notFound-2bae-4028-b53d-0f128479e650';
+        $categoryId = 1;
+
+        $jsonResponse = $this->delete(
+            '/api/categories/'. $categoryId,
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションが不正です。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * ログインセッションが有効期限切れの場合エラーとなること
+     */
+    public function testErrorLoginSessionIsExpired()
+    {
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $categoryId = 1;
+        factory(LoginSession::class)->create([
+            'id'         => $loginSession,
+            'account_id' => 1,
+            'expired_on' => '2018-10-01 00:00:00'
+        ]);
+
+        $jsonResponse = $this->delete(
+            '/api/categories/'. $categoryId,
+            [],
+            ['Authorization' => 'Bearer '.$loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 401;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'セッションの期限が切れました。再度、ログインしてください。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
         $jsonResponse->assertHeader('X-Request-Id');
     }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/104

# Doneの定義
- カテゴリが削除されていること

# 変更点概要

## 仕様的変更点概要
カテゴリを削除する処理を追加。
カテゴリを削除する際、カテゴリとストックのリレーションについても削除を行う。
カテゴリIDのバリデーションを追加
- categoryId : 1から符号無しBIGINTの最大値まで 
　(https://github.com/nekochans/qiita-stocker-backend/pull/86 カテゴリ編集APIで設定しているカテゴリIDのバリデーションと同じ)

## 技術的変更点概要
以下の処理を追加
- 認証処理
- カテゴリIDのバリデーション処理
- カテゴリの削除処理
  - categories
  - categories_names
  - categories_stocks
