### PR TITLE
想定外のエラーのレスポンスを定義する

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Exception;
+use App\Models\Domain\ErrorResponseEntity;
 use App\Models\Domain\ErrorResponseEntityBuilder;
 use App\Models\Domain\Exceptions\ValidationException;
 use App\Models\Domain\Exceptions\BusinessLogicException;
@@ -50,24 +51,52 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $exception)
     {
         if ($exception instanceof ValidationException) {
-            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
-            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
-            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
-            $errorResponseEntityBuilder->setErrors($exception->getErrors());
-            $errorResponseEntity = $errorResponseEntityBuilder->build();
-
+            $errorResponseEntity = $this->convertErrorResponseEntity(
+                $exception->getMessage(),
+                $exception->getCode(),
+                $exception->getErrors()
+            );
             return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
         }
 
         if ($exception instanceof BusinessLogicException) {
-            $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
-            $errorResponseEntityBuilder->setErrorMessage($exception->getMessage());
-            $errorResponseEntityBuilder->setErrorCode($exception->getCode());
-            $errorResponseEntity = $errorResponseEntityBuilder->build();
-
+            $errorResponseEntity = $this->convertErrorResponseEntity(
+                $exception->getMessage(),
+                $exception->getCode()
+            );
             return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
         }
 
-        return parent::render($request, $exception);
+        if ($exception instanceof \Symfony\Component\HttpKernel\Exception\NotFoundHttpException) {
+            $errorResponseEntity = $this->convertErrorResponseEntity('Not Found', 404);
+            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+        }
+
+        if ($exception instanceof \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException) {
+            $errorResponseEntity = $this->convertErrorResponseEntity('Method Not Allowed', 405);
+            return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+        }
+
+        $errorResponseEntity = $this->convertErrorResponseEntity('Internal Server Error', 500);
+        return response()->json($errorResponseEntity->buildBody(), $errorResponseEntity->getErrorCode());
+    }
+
+    /**
+     * ErrorResponseEntity を作成する
+     *
+     * @param string $message
+     * @param int $statusCode
+     * @param array $errors
+     * @return ErrorResponseEntity
+     */
+    private function convertErrorResponseEntity(string $message, int $statusCode, array $errors = []): ErrorResponseEntity
+    {
+        $errorResponseEntityBuilder = new ErrorResponseEntityBuilder();
+        $errorResponseEntityBuilder->setErrorMessage($message);
+        $errorResponseEntityBuilder->setErrorCode($statusCode);
+        if (count($errors)) {
+            $errorResponseEntityBuilder->setErrors($errors);
+        }
+        return  $errorResponseEntityBuilder->build();
     }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/79

# Doneの定義
- 想定外のエラーのレスポンスが定義されていること

# 変更点概要

## 仕様的変更点概要
エラーを下記の通り定義

- NotFoundHttpException
code: 404
messege: Not Found

- MethodNotAllowedHttpException
code: 405
messege: Method Not Allowed

- ドメイン層のException、上記に指定したException以外の場合
code: 500
messege: Internal Server Error

## 技術的変更点概要
`app/Exceptions/Handler.php`に、ドメイン層のException以外の例外のレスポンスを定義