### PR TITLE
セッションの有効期間を修正する

### DIFF
--- a/app/Models/Domain/LoginSession/LoginSessionSpecification.php
+++ b/app/Models/Domain/LoginSession/LoginSessionSpecification.php
@@ -30,4 +30,17 @@ class LoginSessionSpecification
         }
         return [];
     }
+
+    /**
+     * ログインセッションの有効期限を取得する
+     *
+     * @return \DateTime
+     * @throws \Exception
+     */
+    public static function loginSessionExpiration(): \DateTime
+    {
+        $expiredOn = new \DateTime();
+
+        return $expiredOn->add(new \DateInterval('P30D'));
+    }
 }

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\Exceptions\AccountCreatedException;
 use App\Models\Domain\LoginSession\LoginSessionRepository;
 use App\Models\Domain\LoginSession\LoginSessionEntityBuilder;
+use App\Models\Domain\LoginSession\LoginSessionSpecification;
 use App\Models\Domain\Exceptions\LoginSessionExpiredException;
 
 /**
@@ -98,8 +99,7 @@ class AccountScenario
 
             $sessionId = Uuid::uuid4();
 
-            $expiredOn = new \DateTime();
-            $expiredOn->add(new \DateInterval('P30D'));
+            $expiredOn = LoginSessionSpecification::loginSessionExpiration();
 
             $loginSessionEntityBuilder = new LoginSessionEntityBuilder();
             $loginSessionEntityBuilder->setAccountId($accountEntity->getAccountId());

--- a/app/Services/AccountScenario.php
+++ b/app/Services/AccountScenario.php
@@ -98,9 +98,8 @@ class AccountScenario
 
             $sessionId = Uuid::uuid4();
 
-            // TODO 有効期限を適切な期限に修正
             $expiredOn = new \DateTime();
-            $expiredOn->add(new \DateInterval('PT1H'));
+            $expiredOn->add(new \DateInterval('P30D'));
 
             $loginSessionEntityBuilder = new LoginSessionEntityBuilder();
             $loginSessionEntityBuilder->setAccountId($accountEntity->getAccountId());

--- a/app/Services/LoginSessionScenario.php
+++ b/app/Services/LoginSessionScenario.php
@@ -89,9 +89,7 @@ class LoginSessionScenario
             }
 
             $sessionId = Uuid::uuid4();
-
-            $expiredOn = new \DateTime();
-            $expiredOn->add(new \DateInterval('P30D'));
+            $expiredOn = LoginSessionSpecification::loginSessionExpiration();
 
             $loginSessionEntityBuilder = new LoginSessionEntityBuilder();
             $loginSessionEntityBuilder->setAccountId($accountEntity->getAccountId());

--- a/app/Services/LoginSessionScenario.php
+++ b/app/Services/LoginSessionScenario.php
@@ -90,9 +90,8 @@ class LoginSessionScenario
 
             $sessionId = Uuid::uuid4();
 
-            // TODO 有効期限を適切な期限に修正
             $expiredOn = new \DateTime();
-            $expiredOn->add(new \DateInterval('PT1H'));
+            $expiredOn->add(new \DateInterval('P30D'));
 
             $loginSessionEntityBuilder = new LoginSessionEntityBuilder();
             $loginSessionEntityBuilder->setAccountId($accountEntity->getAccountId());


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/135

# Doneの定義
- セッションの有効期間が30日間に設定されていること

# 変更点概要

## 技術的変更点概要
アカウント作成API、ログインAPIで発行しているセッションの有効期間を30日間に変更。