### PR TITLE
カテゴライズAPIを修正する

### DIFF
--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -8,6 +8,7 @@ namespace App\Infrastructure\Repositories\Eloquent;
 use App\Eloquents\Category;
 use App\Eloquents\CategoryName;
 use App\Eloquents\CategoryStock;
+use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Category\CategoryEntities;
@@ -173,14 +174,24 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
      * カテゴリとストックのリレーションを作成する
      *
      * @param CategoryEntity $categoryEntity
-     * @param array $articleIdList
+     * @param StockValues $stockValues
+     * @return mixed|void
      */
-    public function createCategoriesStocks(CategoryEntity $categoryEntity, array $articleIdList)
+    public function createCategoriesStocks(CategoryEntity $categoryEntity, StockValues $stockValues)
     {
-        foreach ($articleIdList as $articleId) {
+        $stockValueList = $stockValues->getStockValues();
+
+        foreach ($stockValueList as $stockValue) {
+            $tags = json_encode($stockValue->getTags());
+
             $categoryStock = new CategoryStock();
             $categoryStock->category_id = $categoryEntity->getId();
-            $categoryStock->article_id = $articleId;
+            $categoryStock->article_id = $stockValue->getArticleId();
+            $categoryStock->title = $stockValue->getTitle();
+            $categoryStock->user_id = $stockValue->getUserId();
+            $categoryStock->profile_image_url = $stockValue->getProfileImageUrl();
+            $categoryStock->article_created_at = $stockValue->getArticleCreatedAt();
+            $categoryStock->tags = $tags;
             $categoryStock->save();
         }
     }

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -5,6 +5,7 @@
 
 namespace App\Models\Domain\Category;
 
+use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Account\AccountEntity;
 
 /**
@@ -63,9 +64,10 @@ interface CategoryRepository
      * カテゴリとストックのリレーションを作成する
      *
      * @param CategoryEntity $categoryEntity
-     * @param array $articleIdList
+     * @param StockValues $stockValues
+     * @return mixed
      */
-    public function createCategoriesStocks(CategoryEntity $categoryEntity, array $articleIdList);
+    public function createCategoriesStocks(CategoryEntity $categoryEntity, StockValues $stockValues);
 
     /**
      * カテゴリとストックのリレーションを取得する

--- a/app/Models/Domain/QiitaApiRepository.php
+++ b/app/Models/Domain/QiitaApiRepository.php
@@ -34,4 +34,13 @@ interface QiitaApiRepository
      * @return StockValues
      */
     public function fetchItems(AccountEntity $accountEntity, CategoryStockEntities $categoryStockEntities): StockValues;
+
+    /**
+     * ArticleIDのリストからアイテム一覧を取得する
+     *
+     * @param AccountEntity $accountEntity
+     * @param array $stockArticleIdList
+     * @return StockValues
+     */
+    public function fetchItemsByArticleIds(AccountEntity $accountEntity, array $stockArticleIdList): StockValues;
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -81,7 +81,8 @@ class AppServiceProvider extends ServiceProvider
                 return new CategoryScenario(
                     $this->app->make(AccountRepository::class),
                     $this->app->make(LoginSessionRepository::class),
-                    $this->app->make(CategoryRepository::class)
+                    $this->app->make(CategoryRepository::class),
+                    $this->app->make(QiitaApiRepository::class)
                 );
             }
         );

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -135,7 +135,7 @@ class CategoryScenario
     }
 
     /**
-     *指定されたカテゴリを更新する
+     * 指定されたカテゴリを更新する
      *
      * @param array $params
      * @return array

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -5,6 +5,7 @@
 
 namespace App\Services;
 
+use App\Models\Domain\QiitaApiRepository;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Category\CategoryNameValue;
@@ -45,19 +46,29 @@ class CategoryScenario
     private $categoryRepository;
 
     /**
+     * QiitaApiRepository
+     *
+     * @var
+     */
+    private $qiitaApiRepository;
+
+    /**
      * CategoryScenario constructor.
      * @param AccountRepository $accountRepository
      * @param LoginSessionRepository $loginSessionRepository
      * @param CategoryRepository $categoryRepository
+     * @param QiitaApiRepository $qiitaApiRepository
      */
     public function __construct(
         AccountRepository $accountRepository,
         LoginSessionRepository $loginSessionRepository,
-        CategoryRepository $categoryRepository
+        CategoryRepository $categoryRepository,
+        QiitaApiRepository $qiitaApiRepository
     ) {
         $this->accountRepository = $accountRepository;
         $this->loginSessionRepository = $loginSessionRepository;
         $this->categoryRepository = $categoryRepository;
+        $this->qiitaApiRepository = $qiitaApiRepository;
     }
 
     /**
@@ -267,7 +278,7 @@ class CategoryScenario
 
             \DB::beginTransaction();
 
-            $categoryEntity->categorize($this->categoryRepository, $accountEntity, $params['articleIds']);
+            $categoryEntity->categorize($this->categoryRepository, $this->qiitaApiRepository, $accountEntity, $params['articleIds']);
 
             \DB::commit();
         } catch (ModelNotFoundException $e) {

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -17,7 +17,12 @@ $factory->define(\App\Eloquents\CategoryName::class, function (Faker $faker) {
 
 $factory->define(\App\Eloquents\CategoryStock::class, function (Faker $faker) {
     return [
-        'category_id'       => '1',
-        'article_id'        => $faker->unique()->regexify('[a-z0-9]{20}'),
-    ];
+        'category_id'              => '1',
+        'article_id'               => $faker->unique()->regexify('[a-z0-9]{20}'),
+        'title'                    => $faker->sentence,
+        'user_id'                  => $faker->userName,
+        'profile_image_url'        => $faker->url,
+        'article_created_at'       => $faker->dateTimeThisDecade,
+        'tags'                     => '',
+        ];
 });

--- a/database/migrations/2018_12_25_114434_create_categories_stocks_table.php
+++ b/database/migrations/2018_12_25_114434_create_categories_stocks_table.php
@@ -17,11 +17,16 @@ class CreateCategoriesStocksTable extends Migration
             $table->increments('id');
             $table->unsignedInteger('category_id');
             $table->string('article_id');
+            $table->text('title');
+            $table->string('user_id');
+            $table->text('profile_image_url');
+            $table->dateTime('article_created_at');
+            $table->text('tags');
             $table->unsignedInteger('lock_version')->default(0);
             $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
             $table->foreign('category_id', 'fk_categories_stocks_01')->references('id')->on('categories');
-            $table->index('category_id', 'idx_categories_stocks_01');
+            $table->index('article_id', 'idx_categories_stocks_01');
         });
     }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/128

# Doneの定義
- カテゴライズAPIの中でQIitaAPIへのリクエストを行なっていること
- 取得したストックの情報がDBに保存されていること

# 変更点概要

## 仕様的変更点概要
カテゴライズAPIに、以下の処理を追加
- QiitaAPIへのリクエスト処理
- 取得したストックの情報をDBに登録する

## 技術的変更点概要
`categories_stocks`テーブルの定義を、ストックの情報を登録できるように修正。
`CategoryEntity`の`categorize()`に、QiitaAPIへのリクエスト処理、DBへの登録処理を追加。
なお、`CategoryStockEntity`の定義を修正する予定であるが、
カテゴライズ済みのストック一覧を取得するAPI `stocks/categories/{id}`を修正する際に、対応する。

# 補足
次のPRでは、カテゴライズ済みのストック一覧を取得するAPI `stocks/categories/{id}`を、
DBから取得したストック情報を返すように修正予定。
