### PR TITLE
カテゴライズ済みのストック取得APIを修正する

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -130,6 +130,7 @@ class CategoryController extends Controller
      * @param Request $request
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
+     * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      * @throws \App\Models\Domain\Exceptions\ValidationException
      * @throws \App\Models\Domain\exceptions\LoginSessionExpiredException

--- a/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
+++ b/app/Infrastructure/Repositories/Api/QiitaApiRepository.php
@@ -10,7 +10,6 @@ use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Stock\FetchStockValues;
 use App\Models\Domain\Stock\StockValueBuilder;
-use App\Models\Domain\Category\CategoryStockEntities;
 
 /**
  * Class QiitaApiRepository
@@ -106,39 +105,6 @@ class QiitaApiRepository extends Repository implements \App\Models\Domain\QiitaA
             array_push($tagNames, $tagName);
         }
         return $tagNames;
-    }
-
-    /**
-     * アイテム一覧を取得する
-     *
-     * @param AccountEntity $accountEntity
-     * @param CategoryStockEntities $categoryStockEntities
-     * @return StockValues
-     */
-    public function fetchItems(AccountEntity $accountEntity, CategoryStockEntities $categoryStockEntities): StockValues
-    {
-        $stockArticleIdList = $categoryStockEntities->buildArticleIdList();
-
-        $promises = [];
-        foreach ($stockArticleIdList as $stockArticleId) {
-            $uri = sprintf('https://qiita.com/api/v2/items/%s', $stockArticleId);
-            $promises[] = $this->getClient()->requestAsync(
-                'GET',
-                $uri,
-                ['headers' => ['Authorization' => 'Bearer '. $accountEntity->getAccessToken()]]
-            );
-        }
-
-        $responses = \GuzzleHttp\Promise\all($promises)->wait();
-
-        $stockValues = [];
-        foreach ($responses as $response) {
-            $stock = json_decode($response->getBody());
-            $stockValue = $this->buildStockValue($stock);
-            array_push($stockValues, $stockValue);
-        }
-
-        return new StockValues(...$stockValues);
     }
 
     /**

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -11,6 +11,7 @@ use App\Eloquents\CategoryStock;
 use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Category\CategoryEntity;
+use App\Models\Domain\Stock\StockValueBuilder;
 use App\Models\Domain\Category\CategoryEntities;
 use App\Models\Domain\Category\CategoryNameValue;
 use App\Models\Domain\Category\CategoryStockEntity;
@@ -230,10 +231,22 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
      */
     private function buildCategoryStockEntity(array $categoryStock): CategoryStockEntity
     {
+        $tags = json_decode($categoryStock['tags'], true);
+        $articleCreatedAt = new \DateTime($categoryStock['article_created_at']);
+
+        $stockValueBuilder = new StockValueBuilder();
+        $stockValueBuilder->setArticleId($categoryStock['article_id']);
+        $stockValueBuilder->setTitle($categoryStock['title']);
+        $stockValueBuilder->setUserId($categoryStock['user_id']);
+        $stockValueBuilder->setProfileImageUrl($categoryStock['profile_image_url']);
+        $stockValueBuilder->setArticleCreatedAt($articleCreatedAt);
+        $stockValueBuilder->setTags($tags);
+        $stockValue = $stockValueBuilder->build();
+
         $categoryStockEntityBuilder = new CategoryStockEntityBuilder();
         $categoryStockEntityBuilder->setId($categoryStock['id']);
         $categoryStockEntityBuilder->setCategoryId($categoryStock['category_id']);
-        $categoryStockEntityBuilder->setArticleId($categoryStock['article_id']);
+        $categoryStockEntityBuilder->setStockValue($stockValue);
 
         return $categoryStockEntityBuilder->build();
     }

--- a/app/Models/Domain/Category/CategoryEntity.php
+++ b/app/Models/Domain/Category/CategoryEntity.php
@@ -112,7 +112,6 @@ class CategoryEntity
         array $articleIds,
         AccountEntity $accountEntity
     ) {
-        // TODO CategoryStockEntityを修正する
         $categoryStockEntities = $this->searchHasCategoryStockEntities($categoryRepository);
         $stockArticleIdList = $categoryStockEntities->buildArticleIdList();
 

--- a/app/Models/Domain/Category/CategoryStockEntities.php
+++ b/app/Models/Domain/Category/CategoryStockEntities.php
@@ -45,7 +45,7 @@ class CategoryStockEntities
 
         $stockArticleIdList = [];
         foreach ($categoryStockEntityList as $categoryStockEntity) {
-            array_push($stockArticleIdList, $categoryStockEntity->getArticleId());
+            array_push($stockArticleIdList, $categoryStockEntity->getStockValue()->getArticleId());
         }
         return $stockArticleIdList;
     }

--- a/app/Models/Domain/Category/CategoryStockEntity.php
+++ b/app/Models/Domain/Category/CategoryStockEntity.php
@@ -5,10 +5,12 @@
 
 namespace App\Models\Domain\Category;
 
+use App\Models\Domain\Stock\StockValue;
+
 class CategoryStockEntity
 {
     /**
-     * カテゴリID
+     * ID
      *
      * @var int
      */
@@ -22,11 +24,11 @@ class CategoryStockEntity
     private $categoryId;
 
     /**
-     * Article ID
+     * StockValue
      *
-     * @var string
+     * @var StockValue
      */
-    private $articleId;
+    private $stockValue;
 
     /**
      * CategoryStockEntity constructor.
@@ -36,7 +38,7 @@ class CategoryStockEntity
     {
         $this->id = $builder->getId();
         $this->categoryId = $builder->getCategoryId();
-        $this->articleId = $builder->getArticleId();
+        $this->stockValue = $builder->getStockValue();
     }
 
     /**
@@ -56,10 +58,10 @@ class CategoryStockEntity
     }
 
     /**
-     * @return string
+     * @return StockValue
      */
-    public function getArticleId(): string
+    public function getStockValue(): StockValue
     {
-        return $this->articleId;
+        return $this->stockValue;
     }
 }

--- a/app/Models/Domain/Category/CategoryStockEntityBuilder.php
+++ b/app/Models/Domain/Category/CategoryStockEntityBuilder.php
@@ -5,6 +5,8 @@
 
 namespace App\Models\Domain\Category;
 
+use App\Models\Domain\Stock\StockValue;
+
 /**
  * Class CategoryStockEntityBuilder
  * @package App\Models\Domain\Category
@@ -12,7 +14,7 @@ namespace App\Models\Domain\Category;
 class CategoryStockEntityBuilder
 {
     /**
-     * カテゴリID
+     * ID
      *
      * @var int
      */
@@ -26,11 +28,11 @@ class CategoryStockEntityBuilder
     private $categoryId;
 
     /**
-     * Article ID
+     * StockValue
      *
-     * @var string
+     * @var StockValue
      */
-    private $articleId;
+    private $stockValue;
 
     /**
      * @return int
@@ -65,19 +67,19 @@ class CategoryStockEntityBuilder
     }
 
     /**
-     * @return string
+     * @return StockValue
      */
-    public function getArticleId(): string
+    public function getStockValue(): StockValue
     {
-        return $this->articleId;
+        return $this->stockValue;
     }
 
     /**
-     * @param string $articleId
+     * @param StockValue $stockValue
      */
-    public function setArticleId(string $articleId): void
+    public function setStockValue(StockValue $stockValue): void
     {
-        $this->articleId = $articleId;
+        $this->stockValue = $stockValue;
     }
 
     public function build()

--- a/app/Models/Domain/QiitaApiRepository.php
+++ b/app/Models/Domain/QiitaApiRepository.php
@@ -8,7 +8,6 @@ namespace App\Models\Domain;
 use App\Models\Domain\Stock\StockValues;
 use App\Models\Domain\Account\AccountEntity;
 use App\Models\Domain\Stock\FetchStockValues;
-use App\Models\Domain\Category\CategoryStockEntities;
 
 /**
  * Interface QiitaApiRepository
@@ -25,15 +24,6 @@ interface QiitaApiRepository
      * @return FetchStockValues
      */
     public function fetchStocks(AccountEntity $accountEntity, int $page, int $perPage): FetchStockValues;
-
-    /**
-     * アイテム一覧を取得する
-     *
-     * @param AccountEntity $accountEntity
-     * @param CategoryStockEntities $categoryStockEntities
-     * @return StockValues
-     */
-    public function fetchItems(AccountEntity $accountEntity, CategoryStockEntities $categoryStockEntities): StockValues;
 
     /**
      * ArticleIDのリストからアイテム一覧を取得する

--- a/app/Services/CategoryScenario.php
+++ b/app/Services/CategoryScenario.php
@@ -6,6 +6,7 @@
 namespace App\Services;
 
 use App\Models\Domain\QiitaApiRepository;
+use GuzzleHttp\Exception\RequestException;
 use App\Models\Domain\Category\CategoryEntity;
 use App\Models\Domain\Account\AccountRepository;
 use App\Models\Domain\Category\CategoryNameValue;
@@ -18,6 +19,7 @@ use App\Models\Domain\Exceptions\UnauthorizedException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Models\Domain\LoginSession\LoginSessionRepository;
 use App\Models\Domain\Exceptions\CategoryNotFoundException;
+use App\Models\Domain\Exceptions\ServiceUnavailableException;
 use App\Models\Domain\exceptions\LoginSessionExpiredException;
 
 class CategoryScenario
@@ -250,6 +252,7 @@ class CategoryScenario
      * @param array $params
      * @throws CategoryNotFoundException
      * @throws LoginSessionExpiredException
+     * @throws ServiceUnavailableException
      * @throws UnauthorizedException
      * @throws ValidationException
      */
@@ -283,6 +286,9 @@ class CategoryScenario
             \DB::commit();
         } catch (ModelNotFoundException $e) {
             throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
+        } catch (RequestException $e) {
+            \DB::rollBack();
+            throw new ServiceUnavailableException();
         } catch (\PDOException $e) {
             \DB::rollBack();
             throw $e;

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -141,7 +141,6 @@ class StockScenario
      * @param array $params
      * @return array
      * @throws CategoryNotFoundException
-     * @throws ServiceUnavailableException
      * @throws UnauthorizedException
      * @throws ValidationException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
@@ -169,36 +168,28 @@ class StockScenario
 
             $categoryStockEntities = $categoryEntity->searchHasCategoryStockEntities($this->categoryRepository, $limit, $offset);
             $totalCount = $this->categoryRepository->getCountCategoriesStocksByCategoryId($categoryEntity->getId());
-
-            $stockValues = $this->qiitaApiRepository->fetchItems($accountEntity, $categoryStockEntities);
         } catch (ModelNotFoundException $e) {
             throw new CategoryNotFoundException(CategoryEntity::categoryNotFoundMessage());
-        } catch (RequestException $e) {
-            throw new ServiceUnavailableException();
         } catch (\PDOException $e) {
             \DB::rollBack();
             throw $e;
         }
 
-        $stockValueList = $stockValues->getStockValues();
+        $CategoryStockEntityList = $categoryStockEntities->getCategoryStockEntities();
 
         $linkList = $this->buildLinkHeaderList($params['uri'], $params['page'], $params['perPage'], $totalCount);
         $link = implode(', ', $linkList);
 
-        $articleIdList = $categoryStockEntities->buildArticleIdList();
-        $CategoryStockEntityList = $categoryStockEntities->getCategoryStockEntities();
-
         $stocks = [];
-        foreach ($stockValueList as $stockValue) {
-            $key = array_search($stockValue->getArticleId(), $articleIdList);
+        foreach ($CategoryStockEntityList as $categoryStockEntity) {
             $stock = [
-                'id'                       => $CategoryStockEntityList[$key]->getId(),
-                'article_id'               => $stockValue->getArticleId(),
-                'title'                    => $stockValue->getTitle(),
-                'user_id'                  => $stockValue->getUserId(),
-                'profile_image_url'        => $stockValue->getProfileImageUrl(),
-                'article_created_at'       => $stockValue->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
-                'tags'                     => $stockValue->getTags(),
+                'id'                       => $categoryStockEntity->getId(),
+                'article_id'               => $categoryStockEntity->getStockValue()->getArticleId(),
+                'title'                    => $categoryStockEntity->getStockValue()->getTitle(),
+                'user_id'                  => $categoryStockEntity->getStockValue()->getUserId(),
+                'profile_image_url'        => $categoryStockEntity->getStockValue()->getProfileImageUrl(),
+                'article_created_at'       => $categoryStockEntity->getStockValue()->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
+                'tags'                     => $categoryStockEntity->getStockValue()->getTags(),
             ];
             array_push($stocks, $stock);
         }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -23,6 +23,6 @@ $factory->define(\App\Eloquents\CategoryStock::class, function (Faker $faker) {
         'user_id'                  => $faker->userName,
         'profile_image_url'        => $faker->url,
         'article_created_at'       => $faker->dateTimeThisDecade,
-        'tags'                     => '',
+        'tags'                     => json_encode(['testTag']),
         ];
 });

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -229,6 +229,47 @@ class CategoryCategorizeTest extends AbstractTestCase
         }
     }
 
+//    /**
+//     * 異常系のテスト
+//     * APIのレスポンスがエラーの場合、エラーとなること
+//     */
+//    public function testErrorApiFailure()
+//    {
+//        $errorResponse = [
+//            'message' => 'Not found',
+//            'type'    => 'not_found'
+//        ];
+//
+//        $mockData = [[404, [], json_encode($errorResponse)], [404, [], json_encode($errorResponse)]];
+//        $this->setMockGuzzle($mockData);
+//
+//        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+//        $accountId = 1;
+//        $categoryId = 1;
+//        $artcleId = 'aabbccddee0000000001';
+//        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
+//
+//        factory(Category::class)->create(['account_id' => $accountId]);
+//        factory(CategoryName::class)->create(['category_id' => 2]);
+//        factory(CategoryStock::class)->create(['category_id' => 2, 'article_id' => $artcleId]);
+//
+//        $jsonResponse = $this->postJson(
+//            '/api/categories/stocks',
+//            [
+//                'id'         => $categoryId,
+//                'articleIds' => [$artcleId, 'aabbccddee0000000002']
+//            ],
+//            ['Authorization' => 'Bearer ' . $loginSession]
+//        );
+//
+//        // 実際にJSONResponseに期待したデータが含まれているか確認する
+//        $expectedErrorCode = 503;
+//        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+//        $jsonResponse->assertJson(['message' => 'Service Unavailable']);
+//        $jsonResponse->assertStatus($expectedErrorCode);
+//        $jsonResponse->assertHeader('X-Request-Id');
+//    }
+
     /**
      * ストックのデータを作成する
      *


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/128

# Doneの定義
- カテゴライズ済みのストック取得APIが、DBから取得したストック情報をレスポンスとして返していること

# 変更点概要

## 仕様的変更点概要
- ストックの情報をDBから取得するように修正

## 技術的変更点概要
`StockScenario`クラスから、QiitaAPIへのリクエスト処理を削除。
`CategoryStockEntity`を修正し、DBから取得したストックをレスポンスに設定している。

また、https://github.com/nekochans/qiita-stocker-backend/pull/139 でカテゴライズAPIの修正を行なったが、QiitaAPIでエラーになった場合の考慮がされていなかったので、エラー処理を追加。
https://github.com/nekochans/qiita-stocker-backend/pull/140/files#diff-94321f889e40a6ff112d866e317dbdefR289