### PR TITLE
ストック取得APIのレスポンスにカテゴリを追加する

### DIFF
--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -276,6 +276,27 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
     }
 
     /**
+     * カテゴリとカテゴライズされているストックのArticleID一覧を取得する
+     *
+     * @param AccountEntity $accountEntity
+     * @param array $articleIdList
+     * @return array
+     */
+    public function searchCategoriesStocksAllByArticleId(AccountEntity $accountEntity, array $articleIdList): array
+    {
+        $categories = Category::select('categories_stocks.id', 'categories_names.name', 'categories_stocks.article_id')
+            ->where('categories.account_id', $accountEntity->getAccountId())
+            ->join('categories_names', 'categories.id', '=', 'categories_names.category_id')
+            ->join('categories_stocks', function ($join) use ($articleIdList) {
+                $join->on('categories.id', '=', 'categories_stocks.category_id')
+                    ->whereIn('categories_stocks.article_id', $articleIdList);
+            })
+            ->get();
+
+        return $categories->toArray();
+    }
+
+    /**
      * カテゴリとストックのリレーションを削除する
      *
      * @param array $categoryStockRelationList

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -284,7 +284,7 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
      */
     public function searchCategoriesStocksAllByArticleId(AccountEntity $accountEntity, array $articleIdList): array
     {
-        $categories = Category::select('categories_stocks.id', 'categories_names.name', 'categories_stocks.article_id')
+        $categories = Category::select('categories.id', 'categories_names.name', 'categories_stocks.article_id')
             ->where('categories.account_id', $accountEntity->getAccountId())
             ->join('categories_names', 'categories.id', '=', 'categories_names.category_id')
             ->join('categories_stocks', function ($join) use ($articleIdList) {

--- a/app/Models/Domain/Category/CategoryRepository.php
+++ b/app/Models/Domain/Category/CategoryRepository.php
@@ -94,6 +94,15 @@ interface CategoryRepository
     ): array;
 
     /**
+     * カテゴリとカテゴライズされているストックのArticleID一覧を取得する
+     *
+     * @param AccountEntity $accountEntity
+     * @param array $articleIdList
+     * @return array
+     */
+    public function searchCategoriesStocksAllByArticleId(AccountEntity $accountEntity, array $articleIdList): array;
+
+    /**
      * カテゴリとストックのリレーションを削除する
      *
      * @param array $categoryStockRelationList

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -99,6 +99,14 @@ class StockScenario
             $accountEntity = $this->findAccountEntity($params, $this->loginSessionRepository, $this->accountRepository);
 
             $fetchStocksValue = $this->qiitaApiRepository->fetchStocks($accountEntity, $params['page'], $params['perPage']);
+
+            $stockValueList = $fetchStocksValue->getStockValues();
+            $stockArticleIdList = [];
+            foreach ($stockValueList as $stockValue) {
+                array_push($stockArticleIdList, $stockValue->getArticleId());
+            }
+
+            $categoryArticleIds = $this->categoryRepository->searchCategoriesStocksAllByArticleId($accountEntity, $stockArticleIdList);
         } catch (ModelNotFoundException $e) {
             throw new UnauthorizedException(LoginSessionEntity::loginSessionUnauthorizedMessage());
         } catch (RequestException $e) {
@@ -107,18 +115,28 @@ class StockScenario
             throw $e;
         }
 
-        $stockValueList = $fetchStocksValue->getStockValues();
         $stocks = [];
 
         foreach ($stockValueList as $stockValue) {
             $stock = [
-                'article_id'               => $stockValue->getArticleId(),
-                'title'                    => $stockValue->getTitle(),
-                'user_id'                  => $stockValue->getUserId(),
-                'profile_image_url'        => $stockValue->getProfileImageUrl(),
-                'article_created_at'       => $stockValue->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
-                'tags'                     => $stockValue->getTags(),
+                'stock' => [
+                    'article_id'               => $stockValue->getArticleId(),
+                    'title'                    => $stockValue->getTitle(),
+                    'user_id'                  => $stockValue->getUserId(),
+                    'profile_image_url'        => $stockValue->getProfileImageUrl(),
+                    'article_created_at'       => $stockValue->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
+                    'tags'                     => $stockValue->getTags(),
+                ],
+                'category' => null
             ];
+
+            $keyIndex = array_search($stockValue->getArticleId(), array_column($categoryArticleIds, 'article_id'));
+            if ($keyIndex !== false) {
+                $stock['category'] = [
+                    'categoryId' => $categoryArticleIds[$keyIndex]['id'],
+                    'name'       => $categoryArticleIds[$keyIndex]['name'],
+                ];
+            }
 
             array_push($stocks, $stock);
         }

--- a/app/Services/StockScenario.php
+++ b/app/Services/StockScenario.php
@@ -126,8 +126,7 @@ class StockScenario
                     'profile_image_url'        => $stockValue->getProfileImageUrl(),
                     'article_created_at'       => $stockValue->getArticleCreatedAt()->format('Y-m-d H:i:s.u'),
                     'tags'                     => $stockValue->getTags(),
-                ],
-                'category' => null
+                ]
             ];
 
             $keyIndex = array_search($stockValue->getArticleId(), array_column($categoryArticleIds, 'article_id'));

--- a/tests/Feature/StockIndexTest.php
+++ b/tests/Feature/StockIndexTest.php
@@ -61,7 +61,6 @@ class StockIndexTest extends AbstractTestCase
         $fetchStockList = [];
         foreach ($stockList as $stock) {
             $expectedStock['stock'] = $stock;
-            $expectedStock['category'] = null;
             $expectedStockList[] = $expectedStock;
 
             $fetchStock = $this->createFetchStocksData($stock);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/137

# Doneの定義
https://github.com/nekochans/qiita-stocker-backend/issues/137 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
ストックに紐づくカテゴリをレスポンスに追加するため、ストック取得APIのレスポンスを変更。
カテゴリに紐づかない場合は、キー名をレスポンスに含めない。

```
[
    {
        "stock": {
            "id": 1,
            "article_id": "1234567890abcdefghij",
            "title": "タイトル",
            "user_id": "test-user",
            "profile_image_url": "http://test.com/test-image.jpag",
            "article_created_at": "2018-12-01 00:00:00.000000",
            "tags": [
                "laravel5.6",
                "laravel",
                "php"
            ]
        },
        "category": {
          "categoryId": 1
          "name": "カテゴリ１"
        }
    },
    {
        "stock": {
            "id": 2,
            "article_id": "1234567890abcdefghij",
            "title": "タイトル2",
            "user_id": "test-user2",
            "profile_image_url": "http://test.com/test-image2.jpag",
            "article_created_at": "2018-12-01 00:00:00.000000",
            "tags": [
                "laravel5.6",
                "laravel",
                "php"
            ]
        }
    }
]
```

## 技術的変更点概要
`StockScenario`シナリオクラスに、ストックに紐づくカテゴリを取得しレスポンスに追加する処理を追加。
テストケースを追加。