### PR TITLE
APIのストックのソート順を変更する

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -66,7 +66,6 @@ class StockController extends Controller
      * @return JsonResponse
      * @throws \App\Models\Domain\Exceptions\CategoryNotFoundException
      * @throws \App\Models\Domain\Exceptions\LoginSessionExpiredException
-     * @throws \App\Models\Domain\Exceptions\ServiceUnavailableException
      * @throws \App\Models\Domain\Exceptions\UnauthorizedException
      * @throws \App\Models\Domain\Exceptions\ValidationException
      */

--- a/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Infrastructure/Repositories/Eloquent/CategoryRepository.php
@@ -211,6 +211,7 @@ class CategoryRepository implements \App\Models\Domain\Category\CategoryReposito
             $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())->get();
         } else {
             $categoryStocks = CategoryStock::where('category_id', $categoryEntity->getId())
+                ->orderBy('id', 'desc')
                 ->offset($offset)
                 ->limit($limit)
                 ->get();

--- a/tests/Feature/StockShowCategorizedTest.php
+++ b/tests/Feature/StockShowCategorizedTest.php
@@ -70,6 +70,7 @@ class StockShowCategorizedTest extends AbstractTestCase
             ]);
         }
 
+        $stockList = array_reverse($stockList);
         $stockList = array_slice($stockList, 20, $perPage);
 
         $uri = sprintf(


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/143

# Doneの定義
https://github.com/nekochans/qiita-stocker-backend/issues/143 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
カテゴライズ済みのストックを取得するAPIのストックが、新たしくカテゴライズしたストックが先頭になるように修正。

## 技術的変更点概要
クエリビルダの`orderBy`を使用して、データを取得する際のソート順を`id`の降順に修正。