### PR TITLE
OPTIONSの場合はメンテナンス 中のエラーを返さないように修正

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,7 +15,6 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
 //        \App\Http\Middleware\CheckForMaintenanceMode::class,
-        \App\Http\Middleware\CheckMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
@@ -61,6 +60,7 @@ class Kernel extends HttpKernel
         'signed'              => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle'            => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'cors'                => \App\Http\Middleware\Cors::class,
+        'maintenance'         => \App\Http\Middleware\CheckMaintenance::class,
         'xRequestId'          => \App\Http\Middleware\XRequestId::class,
     ];
 }

--- a/app/Http/Middleware/CheckMaintenance.php
+++ b/app/Http/Middleware/CheckMaintenance.php
@@ -20,7 +20,7 @@ class CheckMaintenance
      */
     public function handle($request, Closure $next)
     {
-        if ($request->path() !== 'api/statuses' && config('app.maintenance') === true) {
+        if ($request->path() !== 'api/statuses' && $request->method() !== 'OPTIONS' && config('app.maintenance') === true) {
             throw new MaintenanceException('サービスはメンテナンス中です。');
         }
         return $next($request);

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,7 +12,7 @@
 |
 */
 
-Route::middleware(['cors', 'xRequestId'])->group(function () {
+Route::middleware(['cors', 'maintenance', 'xRequestId'])->group(function () {
     Route::options('accounts', function () {
         return response()->json();
     });


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/148

# Doneの定義
- HTTPメソッドが`OPTIOS`の場合、エラーとならないこと

# 変更点概要

## 技術的変更点概要
フロントエンドからリクエストを行なった場合、 HTTPメソッドが`OPTIOS`の際にエラーが発生すると、NetworkErrorとなってしまうため、HTTPメソッドが`OPTIOS`の場合はメンテナンス中のエラーを返さないように修正を行なった。

また、Kernelへの登録の位置がCORS対策のミドルウェアより先になっていたために、CORSエラーが発生していたので、Kernelへの登録箇所を修正。