### PR TITLE
カテゴライズ解除APIのIFを定義

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -149,4 +149,24 @@ class CategoryController extends Controller
 
         return response()->json()->setStatusCode(201);
     }
+
+    /**
+     * カテゴリとストックのリレーションを削除する
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function destroyCategorize(Request $request): JsonResponse
+    {
+        $sessionId = $request->bearerToken();
+        $params = [
+            'sessionId' => $sessionId,
+            'id'        => $request->id,
+        ];
+
+//        TODO シナリオクラスを作成
+//        $this->categoryScenario->destroyCategorize($params);
+
+        return response()->json()->setStatusCode(204);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,11 +53,13 @@ Route::middleware(['cors', 'maintenance', 'xRequestId'])->group(function () {
 
     Route::get('stocks/categories/{id}', 'StockController@showCategorized');
 
-    Route::options('categories/stocks', function () {
+    Route::options('categories/stocks/{id?}', function () {
         return response()->json();
     });
 
     Route::post('categories/stocks', 'CategoryController@categorize');
+
+    Route::delete('categories/stocks/{id}', 'CategoryController@destroyCategorize');
 
     Route::options('statuses', function () {
         return response()->json();

--- a/tests/Feature/CategoryDestroyCategorize.php
+++ b/tests/Feature/CategoryDestroyCategorize.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CategoryDestroyCategorize
+ */
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * Class CategoryDestroyCategorize
+ * @package Tests\Feature
+ */
+class CategoryDestroyCategorize extends AbstractTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 正常系のテスト
+     */
+    public function testSuccess()
+    {
+        $id = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $jsonResponse = $this->delete(
+            '/api/categories/stocks/'. $id,
+            [],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $jsonResponse->assertStatus(204);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
+
+    /**
+     * 異常系のテスト
+     * メンテナンス中の場合エラーとなること
+     */
+    public function testErrorMaintenance()
+    {
+        \Config::set('app.maintenance', true);
+        $id = 1;
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $jsonResponse = $this->delete(
+            '/api/categories/stocks/'. $id,
+            [],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 503;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'サービスはメンテナンス中です。']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+    }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/150

# Doneの定義
- カテゴライズ解除APIのIFが定義されていること

# 変更点概要

## 仕様的変更点概要
カテゴライズ解除APIのIFを定義
`DELETE api/categories/stocks/{id}`

`{id}`には、下記で指定している`id`が設定される想定。
https://github.com/nekochans/qiita-stocker-backend/blob/master/app/Services/StockScenario.php#L203

リクエスト
```
curl -X DELETE -kv \
-H "Authorization: Bearer 04844f4a-d051-4467-9e6f-911d765e5359" \
http://127.0.0.1/api/categories/stocks/1
```

HTTPレスポンスHeader
```
HTTP/1.1 204 No Content
X-Request-Id: 1bbc7a42-3611-421f-b875-dd04593c02a8
```

## 技術的変更点概要
カテゴライズ解除APIのルーティングを設定。