### PR TITLE
php-json-loggerを導入し致命的なエラーはSlackに送信するように改修

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -38,7 +38,16 @@ class Handler extends ExceptionHandler
      */
     public function report(Exception $exception)
     {
-        parent::report($exception);
+        app('log')->alert(
+            $exception,
+            [
+                'request' => [
+                    'url'    => request()->fullUrl(),
+                    'header' => request()->headers->all(),
+                    'params' => request()->all(),
+                ],
+            ]
+        );
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\InfoLogging::class,
     ];
 
     /**

--- a/app/Http/Middleware/InfoLogging.php
+++ b/app/Http/Middleware/InfoLogging.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class InfoLogging
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if ($request->getPathInfo() === '/api/statuses') {
+            return $response;
+        }
+
+        if (!$response->exception) {
+            app('log')->info(
+                $request,
+                [
+                    'response' => [
+                        'header' => $response->headers->all(),
+                        'body'   => $response->original,
+                    ]
+                ]
+            );
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Middleware/XRequestId.php
+++ b/app/Http/Middleware/XRequestId.php
@@ -6,7 +6,6 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Ramsey\Uuid\Uuid;
 
 class XRequestId
 {
@@ -20,7 +19,9 @@ class XRequestId
      */
     public function handle($request, Closure $next)
     {
-        $XRequestId = Uuid::uuid4();
+        // App\Infrastructure\Logger で作成している traceId をそのまま適応
+        // こうすることで X-Request-Id をキーにサーバーのログを検索しやすくしている
+        $XRequestId = app('log')->getTraceId();
 
         return $next($request)
             ->header('X-Request-Id', $XRequestId);

--- a/app/Infrastructure/Logger.php
+++ b/app/Infrastructure/Logger.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Infrastructure;
+
+use Ramsey\Uuid\Uuid;
+use Nekonomokochan\PhpJsonLogger\LoggerBuilder;
+use Nekonomokochan\PhpJsonLogger\SlackHandlerBuilder;
+use Nekonomokochan\PhpJsonLogger\Logger as JsonLogger;
+
+class Logger
+{
+    /**
+     * @param array $config
+     * @return JsonLogger
+     * @throws \Monolog\Handler\MissingExtensionException
+     */
+    public function __invoke(array $config)
+    {
+        $slackHandlerBuilder = new SlackHandlerBuilder($config['slack_token'], $config['slack_channel']);
+
+        $traceId = Uuid::uuid4();
+        $builder = new LoggerBuilder($traceId);
+        $builder->setChannel('qiita-stocker-backend');
+        $builder->setLogLevel(JsonLogger::toMonologLevel($config['level']));
+        $builder->setFileName(storage_path('logs/qiita-stocker-backend-' . php_sapi_name() . '.log'));
+        $builder->setMaxFiles($config['days']);
+        $builder->setSkipClassesPartials(['Illuminate\\']);
+        $builder->setSlackHandler($slackHandlerBuilder->build());
+
+        return $builder->build();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "5.7.*",
         "laravel/tinker": "^1.0",
+        "nekonomokochan/php-json-logger": "^1.2",
         "ramsey/uuid": "^3.8"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43ff1c8172d45fd75fe31ffd39812c7a",
+    "content-hash": "5c4c6367536d264b1af397d806430ac5",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1002,6 +1002,51 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "nekonomokochan/php-json-logger",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nekonomokochan/php-json-logger.git",
+                "reference": "dfc34b0a65747812ff19632981d09cc624c7bdeb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nekonomokochan/php-json-logger/zipball/dfc34b0a65747812ff19632981d09cc624c7bdeb",
+                "reference": "dfc34b0a65747812ff19632981d09cc624c7bdeb",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^1.23",
+                "php": ">= 7.1.0",
+                "ramsey/uuid": "^3.7"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.11",
+                "php": ">= 7.0.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpcov": "^5.0",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nekonomokochan\\PhpJsonLogger\\": "src/PhpJsonLogger"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "keitakn",
+                    "email": "keita.koga.work@gmail.com"
+                }
+            ],
+            "description": "LoggingLibrary for PHP. Output by JSON Format",
+            "time": "2018-07-05T05:58:10+00:00"
         },
         {
             "name": "nesbot/carbon",

--- a/config/logging.php
+++ b/config/logging.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('LOG_CHANNEL', 'stack'),
+    'default' => env('LOG_CHANNEL', 'app'),
 
     /*
     |--------------------------------------------------------------------------
@@ -33,6 +33,15 @@ return [
     */
 
     'channels' => [
+        'app' => [
+            'driver'        => 'custom',
+            'level'         => env('APP_LOG_LEVEL', 'debug'),
+            'days'          => 10,
+            'slack_token'   => env('NOTIFICATION_SLACK_TOKEN'),
+            'slack_channel' => env('NOTIFICATION_SLACK_CHANNEL'),
+            'via'           => App\Infrastructure\Logger::class,
+        ],
+
         'stack' => [
             'driver'   => 'stack',
             'channels' => ['single'],

--- a/createDotenv.js
+++ b/createDotenv.js
@@ -22,6 +22,8 @@
       "FRONTEND_URL",
       "DB_PASSWORD",
       "BACKEND_APP_KEY",
+      "NOTIFICATION_SLACK_TOKEN",
+      "NOTIFICATION_SLACK_CHANNEL",
     ],
     keyMapping: {
       BACKEND_APP_KEY: "APP_KEY",
@@ -32,7 +34,7 @@
       APP_NAME: "qiita-stocker-backend",
       APP_ENV: deployStage,
       APP_DEBUG: true,
-      LOG_CHANNEL: "stack",
+      LOG_CHANNEL: "app",
       DB_CONNECTION: "mysql",
       DB_HOST: deployUtils.findDbHost(deployStage),
       DB_PORT: 3306,


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/117

# Doneの定義
- https://github.com/nekochans/qiita-stocker-backend/issues/117 の完了条件を満たしていること
- 致命的なエラーはSlackのchannelに通知されるようになっていること

# スクリーンショット

こんな感じでSlackに送信される↓（詳しくはSlackのchannelを参照）

<img width="571" alt="slack1" src="https://user-images.githubusercontent.com/11032365/52177129-ec882580-27ff-11e9-9915-9f0ae812cacb.png">

<img width="633" alt="slack2" src="https://user-images.githubusercontent.com/11032365/52177126-df6b3680-27ff-11e9-861f-f338b13c9052.png">

# 変更点概要

## 仕様的変更点概要
Slackに通知する以外にも以下の点が変更されている。

- ログフォーマットがJSON形式に変更（後で加工して集計等がやりやすい為）
- リクエスト毎にinfoログを出力するように変更
infoログは↓のような形

```
{
	"log_level": "INFO",
	"message": "array (\n)",
	"channel": "qiita-stocker-backend",
	"trace_id": "dad06702-4aa3-400e-ab51-f5d39d5bf94f",
	"file": "/opt/qiita-stocker-backend/app/Http/Middleware/InfoLogging.php",
	"line": 30,
	"context": {
		"response": {
			"header": {
				"cache-control": [
					"no-cache, private"
				],
				"date": [
					"Sun, 03 Feb 2019 06:31:19 GMT"
				],
				"content-type": [
					"application/json"
				],
				"x-request-id": [
					"dad06702-4aa3-400e-ab51-f5d39d5bf94f"
				],
				"access-control-allow-origin": [
					"http://127.0.0.1:8080"
				],
				"access-control-allow-methods": [
					"GET, POST, PATCH, PUT, DELETE, OPTIONS"
				],
				"access-control-allow-headers": [
					"Content-Type, Authorization"
				],
				"access-control-expose-headers": [
					"Link, Total-Count"
				],
				"x-ratelimit-limit": [
					60
				],
				"x-ratelimit-remaining": [
					56
				]
			},
			"body": []
		}
	},
	"remote_ip_address": "172.19.0.1",
	"server_ip_address": "172.19.0.4",
	"user_agent": "curl/7.54.0",
	"datetime": "2019-02-03 15:31:19.811711",
	"timezone": "Asia/Tokyo",
	"process_time": 0.26679039001464844
}
```

- 致命的なエラーと判断したエラーはSlackに通知

## 技術的変更点概要
- `nekonomokochan/php-json-logger` をインストール（MonoLogの拡張でPSR3に準拠しつつJSON形式のログを吐き出すライブラリ）
- 専用のログchannelである `app` を定義
- 出力するログファイル名を変更

今までは全て `laravel.log` だったが、以下のように変更になっている。

## artisanコマンド等で発生したログ
`qiita-stocker-backend-cli-YYYY-MM-DD.log`

## HTTPリクエストによって発生したログ（大半はこっちの容量が大きくなる）
`qiita-stocker-backend-fpm-fcgi-YYYY-MM-DD.log`

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 ロギングの仕様についてざっくり把握してくれればおｋ🐱

ちなみに各サーバーのログは [Amazon Kinesis Data Firehose](https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/what-is-this-service.html) を通じてS3Bucketに貯め込む予定だよ！

# 補足情報
- SlackのアクセストークンをSeecretManagerに登録済
- 通知用のSlackChannelを作成済