### PR TITLE
カテゴライズAPIのPDOExceptionが発生しているテストケースを修正

### DIFF
--- a/tests/Feature/AbstractTestCase.php
+++ b/tests/Feature/AbstractTestCase.php
@@ -31,7 +31,10 @@ abstract class AbstractTestCase extends TestCase
     public function setUp()
     {
         parent::setUp();
+    }
 
+    public function tearDown()
+    {
         \DB::statement('SET FOREIGN_KEY_CHECKS=0');
         Account::truncate();
         LoginSession::truncate();
@@ -42,10 +45,7 @@ abstract class AbstractTestCase extends TestCase
         CategoryName::truncate();
         CategoryStock::truncate();
         \DB::statement('SET FOREIGN_KEY_CHECKS=1');
-    }
 
-    public function tearDown()
-    {
         $this->beforeApplicationDestroyed(function () {
             \DB::disconnect();
         });

--- a/tests/Feature/CategoryCategorizeTest.php
+++ b/tests/Feature/CategoryCategorizeTest.php
@@ -229,46 +229,46 @@ class CategoryCategorizeTest extends AbstractTestCase
         }
     }
 
-//    /**
-//     * 異常系のテスト
-//     * APIのレスポンスがエラーの場合、エラーとなること
-//     */
-//    public function testErrorApiFailure()
-//    {
-//        $errorResponse = [
-//            'message' => 'Not found',
-//            'type'    => 'not_found'
-//        ];
-//
-//        $mockData = [[404, [], json_encode($errorResponse)], [404, [], json_encode($errorResponse)]];
-//        $this->setMockGuzzle($mockData);
-//
-//        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
-//        $accountId = 1;
-//        $categoryId = 1;
-//        $artcleId = 'aabbccddee0000000001';
-//        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId, ]);
-//
-//        factory(Category::class)->create(['account_id' => $accountId]);
-//        factory(CategoryName::class)->create(['category_id' => 2]);
-//        factory(CategoryStock::class)->create(['category_id' => 2, 'article_id' => $artcleId]);
-//
-//        $jsonResponse = $this->postJson(
-//            '/api/categories/stocks',
-//            [
-//                'id'         => $categoryId,
-//                'articleIds' => [$artcleId, 'aabbccddee0000000002']
-//            ],
-//            ['Authorization' => 'Bearer ' . $loginSession]
-//        );
-//
-//        // 実際にJSONResponseに期待したデータが含まれているか確認する
-//        $expectedErrorCode = 503;
-//        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
-//        $jsonResponse->assertJson(['message' => 'Service Unavailable']);
-//        $jsonResponse->assertStatus($expectedErrorCode);
-//        $jsonResponse->assertHeader('X-Request-Id');
-//    }
+    /**
+     * 異常系のテスト
+     * APIのレスポンスがエラーの場合、エラーとなること
+     */
+    public function testErrorApiFailure()
+    {
+        $errorResponse = [
+            'message' => 'Not found',
+            'type'    => 'not_found'
+        ];
+
+        $mockData = [[404, [], json_encode($errorResponse)], [404, [], json_encode($errorResponse)]];
+        $this->setMockGuzzle($mockData);
+
+        $loginSession = '54518910-2bae-4028-b53d-0f128479e650';
+        $accountId = 1;
+        $categoryId = 1;
+        $artcleId = 'aabbccddee0000000001';
+        factory(LoginSession::class)->create(['id' => $loginSession, 'account_id' => $accountId]);
+
+        factory(Category::class)->create(['account_id' => $accountId]);
+        factory(CategoryName::class)->create(['category_id' => 2]);
+        factory(CategoryStock::class)->create(['category_id' => 2, 'article_id' => $artcleId]);
+
+        $jsonResponse = $this->postJson(
+            '/api/categories/stocks',
+            [
+                'id'         => $categoryId,
+                'articleIds' => [$artcleId, 'aabbccddee0000000002']
+            ],
+            ['Authorization' => 'Bearer ' . $loginSession]
+        );
+
+        // 実際にJSONResponseに期待したデータが含まれているか確認する
+        $expectedErrorCode = 503;
+        $jsonResponse->assertJson(['code' => $expectedErrorCode]);
+        $jsonResponse->assertJson(['message' => 'Service Unavailable']);
+        $jsonResponse->assertStatus($expectedErrorCode);
+        $jsonResponse->assertHeader('X-Request-Id');
+    }
 
     /**
      * ストックのデータを作成する


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/141

# Doneの定義
https://github.com/nekochans/qiita-stocker-backend/issues/141 の完了の条件が満たされていること

# 変更点概要

## 技術的変更点概要
auto_increment のリセットするために、`AbstractTestCase::setUp()`において、テーブルのTrancateを行なっていたが、この処理が原因でテストケースにおいてPDOExceptionが発生していた。
PDOExceptionの内容は下記の通りであり、trancateの処理によって、transactionに影響を与えていたと思われる。
```
SAVEPOINT trans2 does not exist
```

Trancateの位置をtearDown()に移動することで、エラーが発生しないように修正した。
なお、修正はテストケースのみに影響がある。全てのテストケースが動作することを確認済み。