### PR TITLE
デプロイ時にMigrationが実行されるように変更

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,6 +14,9 @@ hooks:
     - location: hooks/build.sh
       timeout: 1000
       runas: ec2-user
+    - location: hooks/migration.sh
+      timeout: 30
+      runas: ec2-user
     - location: hooks/nginx-restart.sh
       timeout: 300
       runas: root

--- a/hooks/migration.sh
+++ b/hooks/migration.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source /home/ec2-user/.bash_profile
+
+cd /home/ec2-user/qiita-stocker-backend
+
+php artisan migrate


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/157

# Doneの定義
- デプロイ時にMigrationが実行されるようになっていること

# 変更点概要

## 技術的変更点概要
CodeDeployでのデプロイ実行時にMigrationを実行するように変更。

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 https://github.com/nekochans/qiita-stocker-terraform/pull/46 に書いてある通りで、VPCの内にCodeBuildのプロジェクトを作る事が出来なくて（東京リージョンにはまだ未対応な模様）仕方なくこの方法を実装しているよ・・・🐱

この方法のちょっと嫌なところは、Webサーバーが複数台になった時にMigrationが何回も実行されちゃう事だと思っていて、一時的にこの方法にしたものの、Dockerで運用する時には何とかしたいなと思っている！（すぐ思いつくのはAWS BatchでMigration用のDockerコンテナ作ってそれを任意のタイミングで実行するようにする事）

でも今はAPIサーバーが1台だし問題が起きる可能性は低いから、この方法で実装しているよ！

※ Build用のEC2インスタンスを立てる手もあるけど、その為にEC2を立ち上げるのはあまりに勿体ないし、そもそもEC2にSSHしてMigrationを実行という操作自体がミスを生む原因になると思っているので今はこの方法がベストじゃないけどベターかなって思ってる！

# 補足
ステージング環境で動作確認済。

料金節約の為、今はRDSとEC2を停止している。