### PR TITLE
環境変数を利用してnginxのconfを変更する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: ./docker/nginx/Dockerfile
     ports:
       - "80:80"
+    environment:
+      PHP_HOST: php
     depends_on:
       - php
   php:

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,6 +1,10 @@
 FROM nginx:1.15.5-alpine
 
-ADD ./docker/nginx/config/default.conf /etc/nginx/conf.d/default.conf
+ENV PHP_HOST=127.0.0.1
+
+ADD ./docker/nginx/config/default.conf.template /etc/nginx/conf.d/default.conf.template
 
 RUN mkdir -p /var/www/html/public
 ADD ./public/ /var/www/html/public
+
+CMD /bin/sh -c 'sed "s/\${PHP_HOST}/$PHP_HOST/" /etc/nginx/conf.d/default.conf.template  > /etc/nginx/conf.d/default.conf && nginx -g "daemon off;"'

--- a/docker/nginx/config/default.conf.template
+++ b/docker/nginx/config/default.conf.template
@@ -17,7 +17,7 @@ server {
     location ~ \.php$ {
         try_files $uri = 404;
         fastcgi_split_path_info ^(.+\.php)(\.+)$;
-        fastcgi_pass php:9000;
+        fastcgi_pass ${PHP_HOST}:9000;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/173

# Doneの定義
https://github.com/nekochans/qiita-stocker-backend/issues/173 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
ローカル開発環境、ECS(EC2モード、Fargateモード)に合わせてnginxのconfが生成されるように修正。

## 技術的変更点概要
`default.conf.template`に、環境変数`${PHP_HOST}`を設定し、nginxのDockerfileにてconfを生成するように修正。これによって、ECRのリポジトリをEC2モード、Fargateモードで分割する必要がなくなった。

- Fargate
Dockerfileの`ENV PHP_HOST=127.0.0.1`を指定。

- ECS(EC2モード)
タスクの定義で、環境変数`ENV PHP_HOST=php`を設定。Dockerfileの設定より優先される。
→ https://github.com/nekochans/qiita-stocker-terraform/issues/51 で作成中のタスクの定義に追加する予定

- ローカル開発環境
`docker-compose.yml`で環境変数を設定。Dockerfileの設定より優先される。
```
    environment:
      PHP_HOST: php
```

ECS(EC2モード)で動作することを確認ずみ。