### PR TITLE
DockerイメージをPHPを7.3に変更する

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2971,16 +2971,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.1",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
                 "shasum": ""
             },
             "require": {
@@ -2989,7 +2989,7 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
                 "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
@@ -3001,13 +3001,10 @@
                 "symfony/process": "^3.0 || ^4.0",
                 "symfony/stopwatch": "^3.0 || ^4.0"
             },
-            "conflict": {
-                "hhvm": "*"
-            },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -3058,7 +3055,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-10-21T00:32:10+00:00"
+            "time": "2019-02-17T17:44:13+00:00"
         },
         {
             "name": "fzaninotto/faker",

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.10-fpm-alpine
+FROM php:7.3.2-fpm-alpine
 
 COPY . .
 WORKDIR /var/www/html

--- a/docker/php/config/docker-php-ext-opcache.ini
+++ b/docker/php/config/docker-php-ext-opcache.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/opcache.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/opcache.so
 
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=8


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/176

# Doneの定義
https://github.com/nekochans/qiita-stocker-backend/issues/176 の完了条件が満たされていること

# 変更点概要

## 技術的変更点概要
イメージを`php:7.3.2-fpm-alpine`に更新。
上記に伴い、`friendsofphp/php-cs-fixer`についてもアップデート。