### PR TITLE
Migration用のbuildspec.ymlを作成

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,9 +14,6 @@ hooks:
     - location: hooks/build.sh
       timeout: 1000
       runas: ec2-user
-    - location: hooks/migration.sh
-      timeout: 30
-      runas: ec2-user
     - location: hooks/nginx-restart.sh
       timeout: 300
       runas: root

--- a/buildspec-migration.yml
+++ b/buildspec-migration.yml
@@ -7,7 +7,7 @@ phases:
       - composer install
   pre_build:
     commands:
-      - yarn run makeMaintenanceMode:${DEPLOY_STAGE}
+      - yarn run createDotenv:${DEPLOY_STAGE}
   build:
     commands:
       - php artisan migrate

--- a/buildspec-migration.yml
+++ b/buildspec-migration.yml
@@ -1,0 +1,13 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - yarn install
+      - composer install
+  pre_build:
+    commands:
+      - yarn run makeMaintenanceMode:${DEPLOY_STAGE}
+  build:
+    commands:
+      - php artisan migrate

--- a/hooks/migration.sh
+++ b/hooks/migration.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-source /home/ec2-user/.bash_profile
-
-cd /home/ec2-user/qiita-stocker-backend
-
-php artisan migrate

--- a/hooks/nginx-restart.sh
+++ b/hooks/nginx-restart.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-service nginx restart
+systemctl restart nginx.service

--- a/hooks/php-fpm-restart.sh
+++ b/hooks/php-fpm-restart.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-service php-fpm restart
+systemctl restart php-fpm.service


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/178

# Doneの定義
- https://github.com/nekochans/qiita-stocker-backend/issues/178 の完了条件を満たしておりAWS上でCodeBuildのBuildが成功する事

# 変更点概要

## 技術的変更点概要
- `buildspec-migration.yml` を追加してその中でMigrationを行うように修正

# 補足情報
以下の2つのPRと強い関連があるので、これらも同時にマージする必要がある。

- https://github.com/nekochans/qiita-stocker-docker/pull/6
- https://github.com/nekochans/qiita-stocker-terraform/pull/58

以下のように正常にBuild出来る事を確認済。

<img width="703" alt="evidence" src="https://user-images.githubusercontent.com/11032365/54264605-d3b91f80-45b6-11e9-9c9c-76aa506f0183.png">

- 今回の対応でデプロイ時にMigrationを実行する必要がなくなったので削除
- また細かいリファクタリングとしてデプロイ時のserviceコマンドを利用したnginxのrestartコマンドを推奨されている `systemctl` コマンドを使う形に修正。