### PR TITLE
CircleCIの設定を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/php:7.3.4-fpm-stretch
+      - image: circleci/mysql:5.7
+    environment:
+      - APP_NAME: qiita-stocker-backend
+      - APP_DEBUG: true
+      - APP_ENV: testing
+      - APP_KEY: base64:EV4IJnxLNQdTyf7lKiDSxAuXVctckPHzePPfZe0DBBo=
+      - APP_URL: http://127.0.0.1
+      - DB_CONNECTION: circle_test
+      - MYSQL_ALLOW_EMPTY_PASSWORD: true
+      - CORS_ORIGIN: http://127.0.0.1
+      - BROADCAST_DRIVER: log
+      - MAINTENANCE_MODE: false
+      - LOG_CHANNEL: app
+      - NOTIFICATION_SLACK_CHANNEL: ${NOTIFICATION_SLACK_CHANNEL}
+      - NOTIFICATION_SLACK_TOKEN: ${NOTIFICATION_SLACK_TOKEN}
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: sudo docker-php-ext-install pdo_mysql
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "composer.json" }}
+            - v1-dependencies-
+      - run: composer install -n --prefer-dist
+      - save_cache:
+          paths:
+            - ./vendor
+          key: v1-dependencies-{{ checksum "composer.json" }}
+      - run: php artisan migrate
+      - run: php artisan db:seed
+      - run: php ./vendor/bin/phpunit

--- a/config/database.php
+++ b/config/database.php
@@ -78,6 +78,19 @@ return [
             'prefix'   => '',
         ],
 
+        'circle_test' => [
+            'driver'    => 'mysql',
+            'host'      => '127.0.0.1',
+            'port'      => '3306',
+            'database'  => 'circle_test',
+            'username'  => 'root',
+            'password'  => '',
+            'charset'   => 'utf8mb4',
+            'collation' => 'utf8mb4_bin',
+            'prefix'    => '',
+            'strict'    => true,
+            'engine'    => 'InnoDB ROW_FORMAT=DYNAMIC',
+        ]
     ],
 
     /*

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
 # qiita-stocker-backend
+[![CircleCI](https://circleci.com/gh/nekochans/qiita-stocker-backend.svg?style=svg)](https://circleci.com/gh/nekochans/qiita-stocker-backend)
+
 ## 環境変数の設定
 
 1. `.env`、`.env.testing`ファイルを作成します。

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,25 @@ DB_PASSWORD=(YourPassword999)
 CORS_ORIGIN=http://localhost:8080
 MAINTENANCE_MODE=false
 ```
+
+## CircleCIをローカル上で実行する
+
+以下の手順を実行するとCircleCIがローカル上で実行出来るようになります。
+
+CircleCI自体がDockerを使うので、Docker上ではなくあくまでもMac上で実行する必要があります。
+
+詳しい手順はこちらを見て下さい。
+
+https://circleci.com/docs/2.0/local-cli/
+
+依存packageとしてDocker for Macが入ってきますが、大抵の場合、既にインストール済みだと思うので以下を実行すれば良いでしょう。
+
+```bash
+brew install --ignore-dependencies circleci
+```
+
+プロジェクトルートで以下を実行するとBuildが実行されます。
+
+```bash
+circleci build
+```


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/149

# Doneの定義
- CircleCI上でBuildが通る状態になっている事


# 変更点概要

## 技術的変更点概要
- `.circleci/config.yml` を追加
- ローカルで実行する時の手順をREADMEに追加

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 最初、開発用の `docker-compose.yml` を作ってやろうかと思ったけど余計時間がかかりそうだったからCircleCIの公式Dockerイメージを使って作ってあるよ🐱！

いくつかソースコード上にコメントしておいたから確認よろしく！

# 補足情報
以下でBuildが通る事を確認済み。

https://circleci.com/gh/nekochans/qiita-stocker-backend/2
