### PR TITLE
USE_IN_DOCKERによる条件分岐を削除

### DIFF
--- a/app/Infrastructure/Logger.php
+++ b/app/Infrastructure/Logger.php
@@ -24,13 +24,7 @@ class Logger
         $builder->setLogLevel(JsonLogger::toMonologLevel($config['level']));
         $builder->setSkipClassesPartials(['Illuminate\\']);
         $builder->setSlackHandler($slackHandlerBuilder->build());
-
-        if ($config['use_in_docker']) {
-            $builder->setUseInDocker(true);
-        } else {
-            $builder->setFileName(storage_path('logs/qiita-stocker-backend-' . php_sapi_name() . '.log'));
-            $builder->setMaxFiles($config['days']);
-        }
+        $builder->setUseInDocker(true);
 
         return $builder->build();
     }

--- a/app/Infrastructure/Logger.php
+++ b/app/Infrastructure/Logger.php
@@ -24,7 +24,14 @@ class Logger
         $builder->setLogLevel(JsonLogger::toMonologLevel($config['level']));
         $builder->setSkipClassesPartials(['Illuminate\\']);
         $builder->setSlackHandler($slackHandlerBuilder->build());
-        $builder->setUseInDocker(true);
+
+        // テストコード実行時は標準出力すると見にくいのでファイル出力する
+        if ($config['env'] === 'testing') {
+            $builder->setFileName(storage_path('logs/qiita-stocker-backend-' . php_sapi_name() . '.log'));
+            $builder->setMaxFiles($config['days']);
+        } else {
+            $builder->setUseInDocker(true);
+        }
 
         return $builder->build();
     }

--- a/config/logging.php
+++ b/config/logging.php
@@ -40,6 +40,7 @@ return [
             'slack_token'   => env('NOTIFICATION_SLACK_TOKEN'),
             'slack_channel' => env('NOTIFICATION_SLACK_CHANNEL'),
             'via'           => App\Infrastructure\Logger::class,
+            'env'           => env('APP_ENV', 'production'),
         ],
 
         'stack' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -39,7 +39,6 @@ return [
             'days'          => 10,
             'slack_token'   => env('NOTIFICATION_SLACK_TOKEN'),
             'slack_channel' => env('NOTIFICATION_SLACK_CHANNEL'),
-            'use_in_docker' => env('USE_IN_DOCKER'),
             'via'           => App\Infrastructure\Logger::class,
         ],
 

--- a/createDotenv.js
+++ b/createDotenv.js
@@ -21,9 +21,6 @@
     parameterPath: `/${deployStage}/qiita-stocker/api`,
     region: "ap-northeast-1",
     profile: deployUtils.findAwsProfile(deployStage),
-    addParams: {
-      USE_IN_DOCKER: "true",
-    },
   };
 
   await awsEnvCreator.createEnvFile(params);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/188

# Doneの定義
- 不要になった `USE_IN_DOCKER` による条件分岐が削除されている事

# 変更点概要

## 技術的変更点概要
- `USE_IN_DOCKER` による条件分岐を削除

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 最初は単純に `USE_IN_DOCKER` を削除するだけで良いかなと思ったけど、↓みたいにログが見にくくなるから、テスト実行時だけは従来通りにログをファイル出力するようにしたから、今まで通り `storage/logs/*` でログを見れるようになっているよ🐱！

https://circleci.com/gh/nekochans/qiita-stocker-backend/26