### PR TITLE
CodeBuildの設定ファイルをaws/codebuild/standard:2.0に変更

### DIFF
--- a/buildspec-push-ecr.yml
+++ b/buildspec-push-ecr.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   pre_build:
+    runtime-versions:
+      docker: 18
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region ap-northeast-1)

--- a/buildspec-push-ecr.yml
+++ b/buildspec-push-ecr.yml
@@ -1,9 +1,10 @@
 version: 0.2
 
 phases:
-  pre_build:
+  install:
     runtime-versions:
       docker: 18
+  pre_build:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region ap-northeast-1)


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-backend/issues/198

# Doneの定義
- `aws/codebuild/standard:2.0` で正常にBuildが終了する事

# 変更点概要

## 技術的変更点概要
- buildspec.ymlのinstallPHASEにruntime-versionsを追加

今回対象となるのはECRにDockerイメージをプッシュするプロジェクトのみ。

# 補足情報
CodeBuildプロジェクトの変更は https://github.com/nekochans/qiita-stocker-terraform/pull/104 にて対応済、ステージング環境で動作確認済。
